### PR TITLE
chore: add pkg-config to prerequisites for wsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ implemented to make TockLoader usable.
 
 ## Install Prerequisites
 
-### libudev
+### Linux
 
-#### Linux
+```bash
+sudo apt update
+sudo apt install libudev-dev
 ```
-sudo apt-get install -y  libudev-dev
+
+### WSL
+
+```bash
+sudo apt update
+sudo apt install libudev-dev pkg-config
 ```
 
 License


### PR DESCRIPTION
To run tockloader-rs, we need to have pkg-config installed if running under WSL. I am unsure why this is not required for all Linux. It might be the case that most linux distros come with it pre-installed, but WSL does not,