### PR TITLE
Fixed clippy warning `uninlined_format_args`

### DIFF
--- a/tockloader-cli/src/display.rs
+++ b/tockloader-cli/src/display.rs
@@ -5,234 +5,225 @@
 use tockloader_lib::attributes::app_attributes::AppAttributes;
 use tockloader_lib::attributes::system_attributes::SystemAttributes;
 
-// TODO(george-cosma): Fix this
-#[allow(clippy::uninlined_format_args)]
+// ANSI escape codes for colors
+const RESET: &str = "\x1b[0m";
+const BOLD_MAGENTA: &str = "\x1b[1;35m";
+const BOLD_RED: &str = "\x1b[1;31m";
+const BOLD_GREEN: &str = "\x1b[1;32m";
+const BOLD_YELLOW: &str = "\x1b[1;33m";
+
 pub async fn print_list(app_details: &[AppAttributes]) {
     for (i, details) in app_details.iter().enumerate() {
-        println!("\n\x1b[0m\x1b[1;35m ┏━━━━━━━━━━━━━━━━┓");
+        println!("\n{RESET}{BOLD_MAGENTA} ┏━━━━━━━━━━━━━━━━┓");
+        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i} {RESET}{BOLD_RED}┃",);
+        println!("{RESET}{BOLD_YELLOW} ┗━━━━━━━━━━━━━━━━┛");
         println!(
-            "\x1b[0m\x1b[1;31m ┃ \x1b[0m\x1b[1;32m App_{:<9?} \x1b[0m\x1b[1;31m┃",
-            i
-        );
-        println!("\x1b[0m\x1b[1;33m ┗━━━━━━━━━━━━━━━━┛");
-        println!(
-            "\n \x1b[1;32m Name:                {}",
-            details.tbf_header.get_package_name().unwrap()
+            "\n {BOLD_GREEN} Name:             {RESET}{}",
+            details.tbf_header.get_package_name().unwrap(),
         );
 
         println!(
-            " \x1b[1;32m Version:             {}",
-            details.tbf_header.get_binary_version()
+            " {BOLD_GREEN} Version:          {RESET}{}",
+            details.tbf_header.get_binary_version(),
         );
 
         println!(
-            " \x1b[1;32m Enabled:             {}",
-            details.tbf_header.enabled()
+            " {BOLD_GREEN} Enabled:          {RESET}{}",
+            details.tbf_header.enabled(),
         );
 
         println!(
-            " \x1b[1;32m Sticky:              {}",
-            details.tbf_header.sticky()
+            " {BOLD_GREEN} Sticky:           {RESET}{}",
+            details.tbf_header.sticky(),
         );
 
         println!(
-            " \x1b[1;32m Total_Size:          {}\n\n",
-            details.tbf_header.total_size()
+            " {BOLD_GREEN} Total_Size:       {RESET}{}\n\n",
+            details.tbf_header.total_size(),
         );
     }
 }
 
-// TODO(george-cosma): Fix this
-#[allow(clippy::uninlined_format_args)]
 pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut SystemAttributes) {
     for (i, details) in app_details.iter().enumerate() {
-        println!("\n\x1b[0m\x1b[1;35m ┏━━━━━━━━━━━━━━━━┓");
+        println!("\n{RESET}{BOLD_MAGENTA} ┏━━━━━━━━━━━━━━━━┓");
+        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i} {RESET}{BOLD_RED}┃");
+        println!("{RESET}{BOLD_YELLOW} ┗━━━━━━━━━━━━━━━━┛");
+
         println!(
-            "\x1b[0m\x1b[1;31m ┃ \x1b[0m\x1b[1;32m App_{:<9?} \x1b[0m\x1b[1;31m┃",
-            i
-        );
-        println!("\x1b[0m\x1b[1;33m ┗━━━━━━━━━━━━━━━━┛");
-        println!(
-            "\n \x1b[1;32m Name:                {}",
-            details.tbf_header.get_package_name().unwrap()
+            "\n {BOLD_GREEN} Name:             {RESET}{}",
+            details.tbf_header.get_package_name().unwrap(),
         );
 
         println!(
-            " \x1b[1;32m Version:             {}",
-            details.tbf_header.get_binary_version()
+            " {BOLD_GREEN} Version:          {RESET}{}",
+            details.tbf_header.get_binary_version(),
         );
 
         println!(
-            " \x1b[1;32m Enabled:             {}",
-            details.tbf_header.enabled()
+            " {BOLD_GREEN} Enabled:          {RESET}{}",
+            details.tbf_header.enabled(),
         );
 
         println!(
-            " \x1b[1;32m Stricky:             {}",
-            details.tbf_header.sticky()
+            " {BOLD_GREEN} Sticky:           {RESET}{}",
+            details.tbf_header.sticky(),
         );
 
         println!(
-            " \x1b[1;32m Total_Size:          {}",
-            details.tbf_header.total_size()
+            " {BOLD_GREEN} Total_Size:       {RESET}{}",
+            details.tbf_header.total_size(),
         );
 
         println!(
-            " \x1b[1;32m Address in Flash:  {}",
-            system_details.appaddr.unwrap()
+            " {BOLD_GREEN} Address in Flash: {RESET}{}",
+            system_details.appaddr.unwrap(),
         );
 
         println!(
-            " \x1b[1;32m    TBF version:    {}",
-            details.tbf_header.get_binary_version()
+            " {BOLD_GREEN}    TBF version:   {RESET}{}",
+            details.tbf_header.get_binary_version(),
         );
 
         println!(
-            " \x1b[1;32m    header_size:    {}",
-            details.tbf_header.header_size()
+            " {BOLD_GREEN}    header_size:   {RESET}{}",
+            details.tbf_header.header_size(),
         );
 
         println!(
-            " \x1b[1;32m    total_size:     {}",
-            details.tbf_header.total_size()
+            " {BOLD_GREEN}    total_size:    {RESET}{}",
+            details.tbf_header.total_size(),
         );
 
         println!(
-            " \x1b[1;32m    checksum:       {}",
-            details.tbf_header.checksum()
+            " {BOLD_GREEN}    checksum:      {RESET}{}",
+            details.tbf_header.checksum(),
         );
 
-        println!(" \x1b[1;32m    flags:");
+        println!(" {BOLD_GREEN}    flags:{RESET}");
         println!(
-            " \x1b[1;32m        enabled:        {}",
-            details.tbf_header.enabled()
-        );
-
-        println!(
-            " \x1b[1;32m        sticky:         {}",
-            details.tbf_header.sticky()
-        );
-
-        println!(" \x1b[1;32m    TVL: Main (1)",);
-
-        println!(
-            " \x1b[1;32m        init_fn_offset:             {}",
-            details.tbf_header.get_init_function_offset()
+            " {BOLD_GREEN}        enabled:       {RESET}{}",
+            details.tbf_header.enabled(),
         );
 
         println!(
-            " \x1b[1;32m        protected_size:             {}",
-            details.tbf_header.get_protected_size()
+            " {BOLD_GREEN}        sticky:        {RESET}{}",
+            details.tbf_header.sticky(),
+        );
+
+        println!(" {BOLD_GREEN}    TVL: Main (1){RESET}");
+        println!(
+            " {BOLD_GREEN}        init_fn_offset:        {RESET}{}",
+            details.tbf_header.get_init_function_offset(),
         );
 
         println!(
-            " \x1b[1;32m        minimum_ram_size:           {}",
-            details.tbf_header.get_minimum_app_ram_size()
-        );
-
-        println!(" \x1b[1;32m    TVL: Program (9)",);
-
-        println!(
-            " \x1b[1;32m        init_fn_offset:             {}",
-            details.tbf_header.get_init_function_offset()
+            " {BOLD_GREEN}        protected_size:        {RESET}{}",
+            details.tbf_header.get_protected_size(),
         );
 
         println!(
-            " \x1b[1;32m        protected_size:             {}",
-            details.tbf_header.get_protected_size()
+            " {BOLD_GREEN}        minimum_ram_size:      {RESET}{}",
+            details.tbf_header.get_minimum_app_ram_size(),
+        );
+
+        println!(" {BOLD_GREEN}    TVL: Program (9){RESET}");
+        println!(
+            " {BOLD_GREEN}        init_fn_offset:        {RESET}{}",
+            details.tbf_header.get_init_function_offset(),
         );
 
         println!(
-            " \x1b[1;32m        minimum_ram_size:           {}",
-            details.tbf_header.get_minimum_app_ram_size()
+            " {BOLD_GREEN}        protected_size:        {RESET}{}",
+            details.tbf_header.get_protected_size(),
         );
 
         println!(
-            " \x1b[1;32m        binary_end_offset:          {}",
-            details.tbf_header.get_binary_end()
+            " {BOLD_GREEN}        minimum_ram_size:      {RESET}{}",
+            details.tbf_header.get_minimum_app_ram_size(),
         );
 
         println!(
-            " \x1b[1;32m        app_version:                {}",
-            details.tbf_header.get_binary_version()
-        );
-
-        println!(" \x1b[1;32m    TVL: Package Name (3)",);
-
-        println!(
-            " \x1b[1;32m        package_name:               {}",
-            details.tbf_header.get_package_name().unwrap()
-        );
-
-        println!(" \x1b[1;32m    TVL: Kernel Version (8)",);
-
-        println!(
-            " \x1b[1;32m        kernel_major:               {}",
-            details.tbf_header.get_kernel_version().unwrap().0
+            " {BOLD_GREEN}        binary_end_offset:     {RESET}{}",
+            details.tbf_header.get_binary_end(),
         );
 
         println!(
-            " \x1b[1;32m        kernel_minor:               {}",
+            " {BOLD_GREEN}        app_version:           {RESET}{}",
+            details.tbf_header.get_binary_version(),
+        );
+
+        println!(" {BOLD_GREEN}    TVL: Package Name (3){RESET}");
+        println!(
+            " {BOLD_GREEN}        package_name:          {RESET}{}",
+            details.tbf_header.get_package_name().unwrap(),
+        );
+
+        println!(" {BOLD_GREEN}    TVL: Kernel Version (8){RESET}");
+        println!(
+            " {BOLD_GREEN}        kernel_major:          {RESET}{}",
+            details.tbf_header.get_kernel_version().unwrap().0,
+        );
+
+        println!(
+            " {BOLD_GREEN}        kernel_minor:          {RESET}{}",
             details.tbf_header.get_kernel_version().unwrap().1,
         );
 
-        println!("\n \x1b[1;32m    Footer");
+        println!("\n {BOLD_GREEN}    Footer{RESET}");
 
         let mut total_footer_size: u32 = 0;
 
-        //  Usage of +4 is a result of the structure of the Tock Binary Format (https://book.tockos.org/doc/tock_binary_format)
-        //  Because we need the real size of the footer including the type and length.
+        // Usage of +4 is a result of the structure of the Tock Binary Format (https://book.tockos.org/doc/tock_binary_format)
+        // Because we need the real size of the footer including the type and length.
         for footer_details in details.tbf_footers.iter() {
             total_footer_size += footer_details.size + 4;
         }
 
-        println!(
-            " \x1b[1;32m            footer_size:            {}",
-            total_footer_size
-        );
+        println!(" {BOLD_GREEN}            footer_size:       {RESET}{total_footer_size}");
 
-        for (i, footer_details) in details.tbf_footers.iter().enumerate() {
-            println!(" \x1b[1;32m    Footer [{i}] TVL: Credentials");
+        for (j, footer_details) in details.tbf_footers.iter().enumerate() {
+            println!(" {BOLD_GREEN}    Footer [{j}] TVL: Credentials{RESET}");
 
             println!(
-                " \x1b[1;32m        Type:                       {}",
-                footer_details.credentials.get_type()
+                " {BOLD_GREEN}        Type:                  {RESET}{}",
+                footer_details.credentials.get_type(),
             );
 
-            //  Usage of -4 is a result of the structure of the Tock Binary Format (https://book.tockos.org/doc/tock_binary_format)
-            //  Because we only need the size of the credentials without the type and length bytes.
+            // Usage of -4 is a result of the structure of the Tock Binary Format (https://book.tockos.org/doc/tock_binary_format)
+            // Because we only need the size of the credentials without the type and length bytes.
             println!(
-                " \x1b[1;32m        Length:                     {}",
-                footer_details.size - 4
+                " {BOLD_GREEN}        Length:                {RESET}{}",
+                footer_details.size - 4,
             );
         }
     }
 
-    println!("\n\n\x1b[1;32m Kernel Attributes");
+    println!("\n\n{BOLD_GREEN} Kernel Attributes{RESET}");
     println!(
-        "\x1b[1;32m     Sentinel:               {:<10}",
-        system_details.sentinel.clone().unwrap()
+        "{BOLD_GREEN}    Sentinel:          {:<10}{RESET}",
+        system_details.sentinel.clone().unwrap(),
     );
     println!(
-        "\x1b[1;32m     Version:                {:<10}",
-        system_details.kernel_version.unwrap()
+        "{BOLD_GREEN}    Version:           {:<10}{RESET}",
+        system_details.kernel_version.unwrap(),
     );
-    println!("\x1b[1;32m KATLV: APP Memory");
+    println!("{BOLD_GREEN} KATLV: APP Memory{RESET}");
     println!(
-        "\x1b[1;32m     app_memory_start:       {:<10}",
-        system_details.app_mem_start.unwrap()
-    );
-    println!(
-        "\x1b[1;32m     app_memory_len:         {:<10}",
-        system_details.app_mem_len.unwrap()
-    );
-    println!("\x1b[1;32m KATLV: Kernel Binary");
-    println!(
-        "\x1b[1;32m     kernel_binary_start:    {:<10}",
-        system_details.kernel_bin_start.unwrap()
+        "{BOLD_GREEN}    app_memory_start:  {:<10}{RESET}",
+        system_details.app_mem_start.unwrap(),
     );
     println!(
-        "\x1b[1;32m     kernel_binary_len:      {:<10}\n\n",
-        system_details.kernel_bin_len.unwrap()
+        "{BOLD_GREEN}    app_memory_len:    {:<10}{RESET}",
+        system_details.app_mem_len.unwrap(),
+    );
+    println!("{BOLD_GREEN} KATLV: Kernel Binary{RESET}");
+    println!(
+        "{BOLD_GREEN}    kernel_binary_start: {:<10}{RESET}",
+        system_details.kernel_bin_start.unwrap(),
+    );
+    println!(
+        "{BOLD_GREEN}    kernel_binary_len:   {:<10}{RESET}\n\n",
+        system_details.kernel_bin_len.unwrap(),
     );
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes clippy's `uninlined_format_args` by removing  the `#[allow(clippy:uninlined_format_args)]` directives from the tockloader-cli/src/display.rs file.

### TODO or Help Wanted

N/A

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

<!-- #### Features tested:
- [ ] ***feature*** on ***board*** -->


### GitHub Issue

This pull request closes #47 