### PR TITLE
feat: add conventional commits workflow and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+### Pull Request Overview
+
+<!--
+This pull request adds/changes/fixes...
+-->
+
+### TODO or Help Wanted
+
+<!--
+This pull request still needs...
+-->
+
+### Checks
+
+<!--
+Please tick off what you did, and specify what features you've tested on hardware.
+-->
+
+#### Using Rust tooling
+- [ ] Ran `cargo fmt`
+- [ ] Ran `cargo clippy`
+- [ ] Ran `cargo test`
+- [ ] Ran `cargo build`
+
+#### Features tested:
+- [ ] ***feature*** on ***board***
+
+
+### GitHub Issue
+
+<!--
+This pull request closes <GITHUB_ISSUE>
+-->

--- a/.github/workflows/conventional_commits.yaml
+++ b/.github/workflows/conventional_commits.yaml
@@ -1,0 +1,17 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Optional, for private repositories.
+          allowed-commit-types: "feat,fix,chore,refactor" # Optional, set if you want a subset of commit types to be allowed.


### PR DESCRIPTION
### Pull Request Overview

This PR adds a  github action that enforces  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary), and adds this lovely PR template

### TODO or Help Wanted

N/A

### Checks

N/A (changes check themselves here)

### Github Issue

No issue has been created for this.