### PR TITLE
Add possible values to the '--board' cli option

### DIFF
--- a/tockloader-cli/src/known_boards.rs
+++ b/tockloader-cli/src/known_boards.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, PartialEq)]
 pub enum KnownBoardNames {
     NucleoF4,
     MicrobitV2,
@@ -10,5 +11,35 @@ impl KnownBoardNames {
             "microbit-v2" => Some(Self::MicrobitV2),
             _ => None,
         }
+    }
+
+    pub fn to_str(&self) -> &'static str {
+        match &self {
+            KnownBoardNames::NucleoF4 => "nucleo-f4",
+            KnownBoardNames::MicrobitV2 => "microbit-v2",
+        }
+    }
+}
+
+pub fn list_known_board_names() -> Vec<KnownBoardNames> {
+    vec![KnownBoardNames::NucleoF4, KnownBoardNames::MicrobitV2]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_and_to_str_consistent() {
+        for board in list_known_board_names() {
+            assert_eq!(KnownBoardNames::from_str(board.to_str()).unwrap(), board);
+        }
+    }
+
+    #[test]
+    fn list_known_boards_updated() {
+        let backup_list = vec![KnownBoardNames::NucleoF4, KnownBoardNames::MicrobitV2];
+
+        assert_eq!(list_known_board_names(), backup_list, "If this fails it means that you likely forgot to update `list_known_boards`, and subsequently the `list_known_boards_updated` test");
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request limits to possible options possible in the `board` argument, helping the user choose the right board and fix eventual typos.

If the user provides no value:
<img width="597" height="149" alt="image" src="https://github.com/user-attachments/assets/b0afd648-98de-4265-8d42-10f3c47a3235" />

If the user provides a wrong value:
<img width="686" height="136" alt="image" src="https://github.com/user-attachments/assets/755fff6d-2052-4857-b78e-47eb2dd57767" />

### Checks

Added tests to `tocklaoder_cli/known_boards` to keep list up-to-date at all times. Although not currently synced with `lib` list.

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
N/A

### GitHub Issue
N/A