### PR TITLE
Refactor errors

### DIFF
--- a/tockloader-lib/src/command_impl/probers/info.rs
+++ b/tockloader-lib/src/command_impl/probers/info.rs
@@ -5,7 +5,7 @@ use crate::attributes::general_attributes::GeneralAttributes;
 use crate::attributes::system_attributes::SystemAttributes;
 use crate::board_settings::BoardSettings;
 use crate::connection::{Connection, ProbeRSConnection};
-use crate::errors::TockloaderError;
+use crate::errors::{InternalError, TockloaderError};
 use crate::CommandInfo;
 
 #[async_trait]
@@ -15,13 +15,11 @@ impl CommandInfo for ProbeRSConnection {
         settings: &BoardSettings,
     ) -> Result<GeneralAttributes, TockloaderError> {
         if !self.is_open() {
-            return Err(TockloaderError::ConnectionNotOpen);
+            return Err(InternalError::ConnectionNotOpen.into());
         }
         let session = self.session.as_mut().expect("Board must be open");
 
-        let mut core = session
-            .core(self.target_info.core)
-            .map_err(|e| TockloaderError::CoreAccessError(self.target_info.core, e))?;
+        let mut core = session.core(self.target_info.core)?;
 
         // TODO(george-cosma): extract these informations without bootloader
         let system_attributes = SystemAttributes::read_system_attributes_probe(&mut core)?;

--- a/tockloader-lib/src/command_impl/probers/list.rs
+++ b/tockloader-lib/src/command_impl/probers/list.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::attributes::app_attributes::AppAttributes;
 use crate::board_settings::BoardSettings;
 use crate::connection::{Connection, ProbeRSConnection};
-use crate::errors::TockloaderError;
+use crate::errors::{InternalError, TockloaderError};
 use crate::CommandList;
 
 #[async_trait]
@@ -13,13 +13,11 @@ impl CommandList for ProbeRSConnection {
         settings: &BoardSettings,
     ) -> Result<Vec<AppAttributes>, TockloaderError> {
         if !self.is_open() {
-            return Err(TockloaderError::ConnectionNotOpen);
+            return Err(InternalError::ConnectionNotOpen.into());
         }
         let session = self.session.as_mut().expect("Board must be open");
 
-        let mut core = session
-            .core(self.target_info.core)
-            .map_err(|e| TockloaderError::CoreAccessError(self.target_info.core, e))?;
+        let mut core = session.core(self.target_info.core)?;
 
         AppAttributes::read_apps_data_probe(&mut core, settings.start_address)
     }

--- a/tockloader-lib/src/command_impl/serial/info.rs
+++ b/tockloader-lib/src/command_impl/serial/info.rs
@@ -1,14 +1,12 @@
-use std::time::Duration;
-
 use async_trait::async_trait;
 
 use crate::attributes::app_attributes::AppAttributes;
 use crate::attributes::general_attributes::GeneralAttributes;
 use crate::attributes::system_attributes::SystemAttributes;
 use crate::board_settings::BoardSettings;
-use crate::bootloader_serial::{ping_bootloader_and_wait_for_response, Response};
+use crate::bootloader_serial::ping_bootloader_and_wait_for_response;
 use crate::connection::{Connection, SerialConnection};
-use crate::errors::TockloaderError;
+use crate::errors::{InternalError, TockloaderError};
 use crate::CommandInfo;
 
 #[async_trait]
@@ -18,16 +16,11 @@ impl CommandInfo for SerialConnection {
         settings: &BoardSettings,
     ) -> Result<GeneralAttributes, TockloaderError> {
         if !self.is_open() {
-            return Err(TockloaderError::ConnectionNotOpen);
+            return Err(InternalError::ConnectionNotOpen.into());
         }
         let stream = self.stream.as_mut().expect("Board must be open");
 
-        let response = ping_bootloader_and_wait_for_response(stream).await?;
-
-        if response as u8 != Response::Pong as u8 {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let _ = ping_bootloader_and_wait_for_response(stream).await?;
-        }
+        ping_bootloader_and_wait_for_response(stream).await?;
 
         let system_attributes = SystemAttributes::read_system_attributes_serial(stream).await?;
         let app_attributes =

--- a/tockloader-lib/src/command_impl/serial/list.rs
+++ b/tockloader-lib/src/command_impl/serial/list.rs
@@ -1,12 +1,10 @@
-use std::time::Duration;
-
 use async_trait::async_trait;
 
 use crate::attributes::app_attributes::AppAttributes;
 use crate::board_settings::BoardSettings;
-use crate::bootloader_serial::{ping_bootloader_and_wait_for_response, Response};
+use crate::bootloader_serial::ping_bootloader_and_wait_for_response;
 use crate::connection::{Connection, SerialConnection};
-use crate::errors::TockloaderError;
+use crate::errors::{InternalError, TockloaderError};
 use crate::CommandList;
 
 #[async_trait]
@@ -16,17 +14,11 @@ impl CommandList for SerialConnection {
         settings: &BoardSettings,
     ) -> Result<Vec<AppAttributes>, TockloaderError> {
         if !self.is_open() {
-            return Err(TockloaderError::ConnectionNotOpen);
+            return Err(InternalError::ConnectionNotOpen.into());
         }
         let stream = self.stream.as_mut().expect("Board must be open");
 
-        let response = ping_bootloader_and_wait_for_response(stream).await?;
-
-        if response as u8 != Response::Pong as u8 {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            // TODO: more robust retry system (and configurable)
-            let _ = ping_bootloader_and_wait_for_response(stream).await?;
-        }
+        ping_bootloader_and_wait_for_response(stream).await?;
 
         AppAttributes::read_apps_data_serial(stream, settings.start_address).await
     }

--- a/tockloader-lib/src/errors.rs
+++ b/tockloader-lib/src/errors.rs
@@ -8,24 +8,37 @@ use thiserror::Error;
 // Rule of thumb: for public-facing functions or API use `TockloaderError`. For
 // crate-public/private functions you can use more specific errors.
 
+/// Represents all possible errors that can occur within the Tockloader context.
 #[derive(Debug, Error)]
 pub enum TockloaderError {
+    /// Represents an error that can occur during serial communication. This
+    /// does not include errors stemming from bad data or bad bootloader.
     #[error("Serial connection error: {0}")]
     Serial(#[from] SerialError),
 
+    /// Represents an error that can occur while interacting with a probe. This
+    /// does not include errors stemming from bad data.
     #[error("Probe connection error: {0}")]
     Probe(#[from] ProbeError),
 
+    /// Represents an error that can occur while parsing a tab file.
     #[error("TAB file error: {0}")]
     Tab(#[from] TabError),
 
+    /// Represents an error that can occur while parsing Tock OS data or
+    /// otherwise coming from a misconfigured of Tock OS.
     #[error("Tock OS error: {0}")]
     Tock(#[from] TockError),
 
+    /// Represents an error that occurs from internal violations of assumptions,
+    /// or inconsistent state. It usually represents something that the user of
+    /// this library did wrong.
     #[error("Internal tockloader error: {0}")]
     Internal(#[from] InternalError),
 }
 
+/// Represents errors that can occur during serial communication. This does not
+/// include errors stemming from bad data or bad bootloader.
 #[derive(Debug, Error)]
 pub enum SerialError {
     #[error("Failed to interface in serial using tokio_serial: {0}")]
@@ -35,6 +48,8 @@ pub enum SerialError {
     IO(#[from] io::Error),
 }
 
+/// Represents errors that can occur while interacting with a probe. This does
+/// not include errors stemming from bad data.
 #[derive(Debug, Error)]
 pub enum ProbeError {
     #[error("Failed to interact with probe: {0}")]
@@ -47,6 +62,7 @@ pub enum ProbeError {
     Flashing(#[from] probe_rs::flashing::FlashError),
 }
 
+/// Represents errors that can occur while parsing a tab file.
 #[derive(Debug, Error)]
 pub enum TabError {
     #[error("Failed to use tab due to IO error: {0}")]
@@ -65,6 +81,8 @@ pub enum TabError {
     MissingBinary(String),
 }
 
+/// Represents errors that can occur while parsing Tock OS data or otherwise
+/// coming from a misconfigured of Tock OS.
 #[derive(Debug, Error)]
 pub enum TockError {
     #[error("Bootloader returned an invalid header: {0} {1}")]
@@ -83,6 +101,7 @@ pub enum TockError {
     MissingAttribute(String),
 }
 
+/// Represents errors that can occur while parsing attributes.
 #[derive(Debug, Error)]
 pub enum AttributeParseError {
     #[error("Expected attribute to be a valid number. Inner: {0}")]
@@ -92,6 +111,8 @@ pub enum AttributeParseError {
     InvalidString(#[from] std::string::FromUtf8Error),
 }
 
+/// Represents internal violations of assumptions, or inconsistent state. It
+/// usually represents something that the user of this library did wrong.
 #[derive(Debug, Error)]
 pub enum InternalError {
     #[error("Operation failed due to board not being open.")]

--- a/tockloader-lib/src/errors.rs
+++ b/tockloader-lib/src/errors.rs
@@ -5,55 +5,125 @@
 use std::io;
 use thiserror::Error;
 
-// TODO(george-cosma): Split this. Possibly each meta-function (install, list,
-// ...) should have its own error type + error type for connection. We can have
-// more detailed errors as "sources" for more generic error types, if we TRULY
-// need to know why probe-rs failed. Or serial.
+// Rule of thumb: for public-facing functions or API use `TockloaderError`. For
+// crate-public/private functions you can use more specific errors.
 
 #[derive(Debug, Error)]
 pub enum TockloaderError {
-    #[error("Failed due to the connection not being open.")]
-    ConnectionNotOpen,
+    #[error("Serial connection error: {0}")]
+    Serial(#[from] SerialError),
 
-    #[error("Error occurred while trying to access core: {0}")]
-    CoreAccessError(usize, probe_rs::Error),
+    #[error("Probe connection error: {0}")]
+    Probe(#[from] ProbeError),
 
-    #[error("Failed to initialize probe_rs connection due to a communication error. Inner: {0}")]
-    ProbeRsInitializationError(#[from] probe_rs::probe::DebugProbeError),
+    #[error("TAB file error: {0}")]
+    Tab(#[from] TabError),
 
-    #[error("Failed to establish communication with board. Inner: {0}")]
-    ProbeRsCommunicationError(probe_rs::Error),
+    #[error("Tock OS error: {0}")]
+    Tock(#[from] TockError),
 
-    #[error("Failed to read from debug probe. Inner: {0}")]
-    ProbeRsReadError(probe_rs::Error),
+    #[error("Internal tockloader error: {0}")]
+    Internal(#[from] InternalError),
+}
 
-    #[error("Failed to write binary. Inner: {0}")]
-    ProbeRsWriteError(#[from] probe_rs::flashing::FlashError),
+#[derive(Debug, Error)]
+pub enum SerialError {
+    #[error("Failed to interface in serial using tokio_serial: {0}")]
+    TokioSerial(#[from] tokio_serial::Error),
 
-    #[error("Failed to initialize serial connection due to a communication error. Inner: {0}")]
-    SerialInitializationError(#[from] tokio_serial::Error),
+    #[error("Failed to perform read/write operations on serial port: {0}")]
+    IO(#[from] io::Error),
+}
 
-    #[error("Bootloader did not respond properly: {0}")]
-    BootloaderError(u8),
+#[derive(Debug, Error)]
+pub enum ProbeError {
+    #[error("Failed to interact with probe: {0}")]
+    Probe(#[from] probe_rs::probe::DebugProbeError),
 
-    #[error("No binary found for {0} architecture.")]
-    NoBinaryError(String),
+    #[error("Communication with board failed: {0}")]
+    Communication(#[from] probe_rs::Error),
 
-    #[error("App data could not be parsed.")]
-    ParsingError(tbf_parser::types::TbfParseError),
+    #[error("Failed to flash data: {0}")]
+    Flashing(#[from] probe_rs::flashing::FlashError),
+}
 
-    #[error("Failed to perform read/write operations on serial port. Inner: {0}")]
-    IOError(#[from] io::Error),
+#[derive(Debug, Error)]
+pub enum TabError {
+    #[error("Failed to use tab due to IO error: {0}")]
+    IO(io::Error),
 
-    #[error("Expected board attribute to be present")]
-    MisconfiguredBoard(String),
-
-    #[error("Failed to use tab from provided path. Inner: {0}")]
-    UnusableTab(io::Error),
-
-    #[error("Failed to parse metadata. Inner: {0}")]
+    #[error("Failed to parse metadata: {0}")]
     InvalidMetadata(toml::de::Error),
 
-    #[error("No metadata.toml found.")]
-    NoMetadata,
+    #[error("No metadata.toml found inside the tab file.")]
+    MissingMetadata,
+
+    #[error("App data could not be parsed from tab file: {0:?}")]
+    Parsing(tbf_parser::types::TbfParseError),
+
+    #[error("No binary data found for {0} architecture")]
+    MissingBinary(String),
+}
+
+#[derive(Debug, Error)]
+pub enum TockError {
+    #[error("Bootloader returned an invalid header: {0} {1}")]
+    BootloaderBadHeader(u8, u8),
+
+    #[error("Bootloader command did not finish in time")]
+    BootloaderTimeout,
+
+    #[error("Application data could not be parsed due to malformed header: {0:?}")]
+    InvalidAppTbfHeader(tbf_parser::types::TbfParseError),
+
+    #[error("Failed to parse attribute: {0}")]
+    AttributeParsing(#[from] AttributeParseError),
+
+    #[error("Attribute does not exist: {0}")]
+    MissingAttribute(String),
+}
+
+#[derive(Debug, Error)]
+pub enum AttributeParseError {
+    #[error("Expected attribute to be a valid number. Inner: {0}")]
+    InvalidNumber(#[from] std::num::ParseIntError),
+
+    #[error("Expected attribute to be a valid string. Inner: {0}")]
+    InvalidString(#[from] std::string::FromUtf8Error),
+}
+
+#[derive(Debug, Error)]
+pub enum InternalError {
+    #[error("Operation failed due to board not being open.")]
+    ConnectionNotOpen,
+
+    #[error("Operation failed due to board not being in bootloader mode or not having a bootloader present.")]
+    BootloaderNotPresent,
+
+    #[error("Missing or invalid board setting: {0}")]
+    MisconfiguredBoardSettings(String),
+}
+
+impl From<tokio_serial::Error> for TockloaderError {
+    fn from(value: tokio_serial::Error) -> Self {
+        TockloaderError::Serial(value.into())
+    }
+}
+
+impl From<probe_rs::Error> for TockloaderError {
+    fn from(value: probe_rs::Error) -> Self {
+        TockloaderError::Probe(value.into())
+    }
+}
+
+impl From<probe_rs::flashing::FlashError> for TockloaderError {
+    fn from(value: probe_rs::flashing::FlashError) -> Self {
+        TockloaderError::Probe(value.into())
+    }
+}
+
+impl From<probe_rs::probe::DebugProbeError> for TockloaderError {
+    fn from(value: probe_rs::probe::DebugProbeError) -> Self {
+        TockloaderError::Probe(value.into())
+    }
 }

--- a/tockloader-lib/src/lib.rs
+++ b/tockloader-lib/src/lib.rs
@@ -18,7 +18,7 @@ use tokio_serial::SerialPortInfo;
 use crate::attributes::app_attributes::AppAttributes;
 use crate::attributes::general_attributes::GeneralAttributes;
 use crate::board_settings::BoardSettings;
-use crate::errors::TockloaderError;
+use crate::errors::*;
 use crate::tabs::tab::Tab;
 
 pub fn list_debug_probes() -> Vec<DebugProbeInfo> {
@@ -26,7 +26,7 @@ pub fn list_debug_probes() -> Vec<DebugProbeInfo> {
 }
 
 pub fn list_serial_ports() -> Result<Vec<SerialPortInfo>, TockloaderError> {
-    tokio_serial::available_ports().map_err(TockloaderError::SerialInitializationError)
+    tokio_serial::available_ports().map_err(|e| TockloaderError::Serial(e.into()))
 }
 
 // TODO(george-cosma): Examine if we need to split these functions into smaller

--- a/tockloader-lib/src/tabs/metadata.rs
+++ b/tockloader-lib/src/tabs/metadata.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright OXIDOS AUTOMOTIVE 2024.
 
-use crate::errors::TockloaderError;
+use crate::errors::{TabError, TockloaderError};
 use serde::Deserialize;
 
 #[allow(dead_code)]
@@ -25,7 +25,7 @@ pub(super) struct Metadata {
 
 impl Metadata {
     pub fn new(metadata: String) -> Result<Self, TockloaderError> {
-        toml::from_str(&metadata).map_err(TockloaderError::InvalidMetadata)
+        toml::from_str(&metadata).map_err(|e| TabError::InvalidMetadata(e).into())
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull requests refactors the errors of `tockloader-lib`. The main goal was to make all errors more distinct (having a specific error for each fail-case) while still having the end-API using a clear and concise set of errors. If a user needs detail as for the fail reason, the inner errors are there to help. In future, `tockloader-cli` and `tock-ui` should carefully inspect these errors and throw custom messages for common user errors (e.g. not starting bootloader when doing so automatically is not possible and demanding to use a serial connection)

### Checks

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***info*** with **probe-rs** on  microbit-v2
<img width="1300" height="1083" alt="image" src="https://github.com/user-attachments/assets/eaa4fdcb-9c6e-4100-9dc6-568f4a39007d" />

- [x] ***info*** with **serial** on  microbit-v2
<img width="1298" height="990" alt="image" src="https://github.com/user-attachments/assets/54b44a10-0580-457c-ad95-e69d8dfede53" />

- [x] ***list*** with **probe-rs** on  microbit-v2
<img width="1309" height="313" alt="image" src="https://github.com/user-attachments/assets/b654dd41-5364-4d00-8223-38308cf07c89" />

- [x] ***list*** with **serial** on  microbit-v2
<img width="1302" height="301" alt="image" src="https://github.com/user-attachments/assets/62a2df7d-dc4f-4058-8611-2d99286ba369" />

- [x] ***install*** with **probe-rs** on  microbit-v2
This works, but causes runs into issue #73 

- [ ] ***install*** with **serial** on  microbit-v2
Code not implemented, waiting on #48 . Code should function without issues.


### GitHub Issue

Closes #25 