### PR TITLE
chore: add tauri prerequisites in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ you the most flexibility:
 
 ## Install Dev Prerequisites
 
+### All distrubitions
+
+For all distributions, you must install [tauri
+prerequisites](https://tauri.app/start/prerequisites/) if you want to work on
+`tock-ui`, or to have rust-analyzer work out of the box. You can go without
+installing these if you configure rust-analyzer to ignore the `tock-ui` project.
+
 ### Linux
 
 ```bash


### PR DESCRIPTION
### Pull Request Overview

This PR adds the necessary requirements to compile the `tock-ui` project. Running `cargo build` without them install will fail, and will also result in rust-analyzer failing. Although not strictly necessary for the other parts of `tockloader-rs`, it is better to have them, and to tell the user to also get them.

### GitHub Issue
N/A