### PR TITLE
fix: fix spacing issue for display of info/list commands in headers

### DIFF
--- a/tockloader-cli/src/display.rs
+++ b/tockloader-cli/src/display.rs
@@ -15,7 +15,7 @@ const BOLD_YELLOW: &str = "\x1b[1;33m";
 pub async fn print_list(app_details: &[AppAttributes]) {
     for (i, details) in app_details.iter().enumerate() {
         println!("\n{RESET}{BOLD_MAGENTA} ┏━━━━━━━━━━━━━━━━┓");
-        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i} {RESET}{BOLD_RED}┃",);
+        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i:<9} {RESET}{BOLD_RED}┃",);
         println!("{RESET}{BOLD_YELLOW} ┗━━━━━━━━━━━━━━━━┛");
         println!(
             "\n {BOLD_GREEN} Name:             {RESET}{}",
@@ -47,7 +47,7 @@ pub async fn print_list(app_details: &[AppAttributes]) {
 pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut SystemAttributes) {
     for (i, details) in app_details.iter().enumerate() {
         println!("\n{RESET}{BOLD_MAGENTA} ┏━━━━━━━━━━━━━━━━┓");
-        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i} {RESET}{BOLD_RED}┃");
+        println!("{RESET}{BOLD_RED} ┃ {RESET}{BOLD_GREEN} App_{i:<9} {RESET}{BOLD_RED}┃");
         println!("{RESET}{BOLD_YELLOW} ┗━━━━━━━━━━━━━━━━┛");
 
         println!(


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a small display glitch in the `info` and `list`  commands.

Before:
<img width="643" height="303" alt="image" src="https://github.com/user-attachments/assets/47f4f6e8-f20c-4569-a6cf-8770cdd8a746" />

After:
<img width="612" height="224" alt="image" src="https://github.com/user-attachments/assets/d8ce64b0-0fef-4224-8577-21a423a7d993" />

### Checks

Verified by manual test

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

### GitHub Issue
N/A