### PR TITLE
chore: use Github generated env variable instead of hardcoded value

### DIFF
--- a/.github/workflows/issue-builder.yml
+++ b/.github/workflows/issue-builder.yml
@@ -168,9 +168,8 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           UPSTREAM: "tock/tock"
-          DOWNSTREAM: "WyliodrinEmbeddedIoT/tockloader-rs"
+          DOWNSTREAM: ${{ github.repository }}
           TITLE: Bring updates from 'tock-tbf' to 'tbf-parser'
           LABELS: D3-TBF PARSER,P1-CRITICAL,EXCLUSIVE LABEL
           BODY: |

--- a/.github/workflows/sha-checker.yml
+++ b/.github/workflows/sha-checker.yml
@@ -46,6 +46,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPSTREAM: "tock/tock"
-          DOWNSTREAM: "WyliodrinEmbeddedIoT/tockloader-rs"
+          DOWNSTREAM: ${{ github.repository }}
         
           


### PR DESCRIPTION
### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->
This pull request changes the `issue-builder` and `sha-checker` workflows to be repository-agnostic by changing the DOWNSTREAM environment variable to use the Github-generated value instead of the hard-coded value.

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***feature*** on ***board***


### GitHub Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
This pull request closes [#83](https://github.com/WyliodrinEmbeddedIoT/tockloader-rs/issues/83)