### PR TITLE
feat: erase_apps

### DIFF
--- a/tockloader-cli/src/cli.rs
+++ b/tockloader-cli/src/cli.rs
@@ -53,6 +53,11 @@ fn get_subcommands() -> Vec<Command> {
             .args(get_app_args())
             .args(get_channel_args())
             .arg_required_else_help(false),
+        Command::new("erase-apps")
+            .about("Erase apps")
+            .args(get_app_args())
+            .args(get_channel_args())
+            .arg_required_else_help(false),
     ]
 }
 

--- a/tockloader-cli/src/main.rs
+++ b/tockloader-cli/src/main.rs
@@ -18,7 +18,8 @@ use tockloader_lib::connection::{
 use tockloader_lib::known_boards::KnownBoard;
 use tockloader_lib::tabs::tab::Tab;
 use tockloader_lib::{
-    list_debug_probes, list_serial_ports, CommandInfo, CommandInstall, CommandList,
+    list_debug_probes, list_serial_ports, CommandEraseApps, CommandInfo, CommandInstall,
+    CommandList,
 };
 
 fn get_serial_target_info(user_options: &ArgMatches) -> SerialTargetInfo {
@@ -227,6 +228,15 @@ async fn main() -> Result<()> {
             conn.install_app(&settings, tab_file)
                 .await
                 .context("Failed to install app.")?;
+        }
+        Some(("erase-apps", sub_matches)) => {
+            cli::validate(&mut cmd, sub_matches);
+            let mut conn = open_connection(sub_matches).await?;
+            let settings = get_board_settings(sub_matches);
+
+            conn.erase_apps(&settings)
+                .await
+                .context("Failed to erase apps.")?;
         }
         _ => {
             println!("Could not run the provided subcommand.");

--- a/tockloader-lib/src/command_impl/generalized.rs
+++ b/tockloader-lib/src/command_impl/generalized.rs
@@ -6,7 +6,7 @@ use crate::board_settings::BoardSettings;
 use crate::connection::TockloaderConnection;
 use crate::errors::TockloaderError;
 use crate::tabs::tab::Tab;
-use crate::{CommandInfo, CommandInstall, CommandList};
+use crate::{CommandEraseApps, CommandInfo, CommandInstall, CommandList};
 
 #[async_trait]
 impl CommandList for TockloaderConnection {
@@ -44,6 +44,16 @@ impl CommandInstall for TockloaderConnection {
         match self {
             TockloaderConnection::ProbeRS(conn) => conn.install_app(settings, tab_file).await,
             TockloaderConnection::Serial(conn) => conn.install_app(settings, tab_file).await,
+        }
+    }
+}
+
+#[async_trait]
+impl CommandEraseApps for TockloaderConnection {
+    async fn erase_apps(&mut self, settings: &BoardSettings) -> Result<(), TockloaderError> {
+        match self {
+            TockloaderConnection::ProbeRS(conn) => conn.erase_apps(settings).await,
+            TockloaderConnection::Serial(_conn) => todo!(),
         }
     }
 }

--- a/tockloader-lib/src/command_impl/probers/erase_apps.rs
+++ b/tockloader-lib/src/command_impl/probers/erase_apps.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use probe_rs::flashing::DownloadOptions;
+
+use crate::board_settings::BoardSettings;
+use crate::connection::{Connection, ProbeRSConnection};
+use crate::errors::{InternalError, TockloaderError};
+use crate::CommandEraseApps;
+
+#[async_trait]
+impl CommandEraseApps for ProbeRSConnection {
+    async fn erase_apps(&mut self, settings: &BoardSettings) -> Result<(), TockloaderError> {
+        if !self.is_open() {
+            return Err(InternalError::ConnectionNotOpen.into());
+        }
+        let session = self.session.as_mut().expect("Board must be open");
+
+        let mut loader = session.target().flash_loader();
+
+        let address = settings.start_address;
+        // A single 0x0 byte is enough to invalidate the tbf header and make it all programs
+        // unreadable to tockloader. This does mean app information will still exist on the board,
+        // but they will be overwritten when the space is needed.
+        loader.add_data((address as u32).into(), &[0x0])?;
+
+        let mut options = DownloadOptions::default();
+        options.keep_unwritten_bytes = true;
+
+        // Finally, the data can be programmed
+        loader.commit(session, options)?;
+        Ok(())
+    }
+}

--- a/tockloader-lib/src/command_impl/probers/mod.rs
+++ b/tockloader-lib/src/command_impl/probers/mod.rs
@@ -1,3 +1,4 @@
+pub mod erase_apps;
 pub mod info;
 pub mod install;
 pub mod list;

--- a/tockloader-lib/src/lib.rs
+++ b/tockloader-lib/src/lib.rs
@@ -59,3 +59,8 @@ pub trait CommandInstall {
         tab_file: Tab,
     ) -> Result<(), TockloaderError>;
 }
+
+#[async_trait]
+pub trait CommandEraseApps {
+    async fn erase_apps(&mut self, settings: &BoardSettings) -> Result<(), TockloaderError>;
+}


### PR DESCRIPTION
### Pull Request Overview


This pull request adds the erase-apps feature


### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***erase-apps*** on ***microbit-v2***
- I installed apps using both tockloader-rs and the python version. I ran ***erase-apps*** . It worked as expected in both cases, with only one or more apps installed.

### GitHub Issue


This pull request closes <[Implement erase_apps #87 ](https://github.com/WyliodrinEmbeddedIoT/tockloader-rs/issues/87)>
