### PR TITLE
fix: the program distinguishes padding from app

### DIFF
--- a/tockloader-lib/src/attributes/app_attributes.rs
+++ b/tockloader-lib/src/attributes/app_attributes.rs
@@ -112,10 +112,18 @@ impl AppAttributes {
             // The end of the application binary marks the beginning of the
             // footer.
             //
-            // TODO(george-cosma): This is not always true, `get_binary_end`
+            // Note: This is not always true, `get_binary_end`
             // does not make sense if the application is just padding. This can
             // crash the process.
             let binary_end_offset = header.get_binary_end();
+
+            match &header {
+                TbfHeader::TbfHeaderV2(_hd) => {}
+                _ => {
+                    appaddr += total_size as u64;
+                    continue;
+                }
+            };
 
             let mut footers: Vec<TbfFooter> = vec![];
             let total_footers_size = total_size - binary_end_offset;
@@ -233,6 +241,14 @@ impl AppAttributes {
             let header = parse_tbf_header(&header_data, tbf_version)
                 .map_err(TockError::InvalidAppTbfHeader)?;
             let binary_end_offset = header.get_binary_end();
+
+            match &header {
+                TbfHeader::TbfHeaderV2(_hd) => {}
+                _ => {
+                    appaddr += total_size as u64;
+                    continue;
+                }
+            };
 
             let mut footers: Vec<TbfFooter> = vec![];
             let total_footers_size = total_size - binary_end_offset;


### PR DESCRIPTION
### Pull Request Overview

This pull request enables the program to distinguish an app from padding.
As a solution, I added a match statement as filtering to distinguish between valid tbf headers v2 and padding regions, making sure to only process legitimate headers.


### TODO or Help Wanted

### Checks

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***Info with tockloader-rs*** on ***microbit-v2***


- [x] ***Info with tockloader*** on ***microbit-v2***
