### PR TITLE
feat: erase_apps(serial)

### DIFF
--- a/tockloader-lib/src/command_impl/generalized.rs
+++ b/tockloader-lib/src/command_impl/generalized.rs
@@ -53,7 +53,7 @@ impl CommandEraseApps for TockloaderConnection {
     async fn erase_apps(&mut self, settings: &BoardSettings) -> Result<(), TockloaderError> {
         match self {
             TockloaderConnection::ProbeRS(conn) => conn.erase_apps(settings).await,
-            TockloaderConnection::Serial(_conn) => todo!(),
+            TockloaderConnection::Serial(conn) => conn.erase_apps(settings).await,
         }
     }
 }

--- a/tockloader-lib/src/command_impl/serial/erase_apps.rs
+++ b/tockloader-lib/src/command_impl/serial/erase_apps.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+
+use crate::board_settings::BoardSettings;
+use crate::bootloader_serial::{
+    issue_command, ping_bootloader_and_wait_for_response, Command, Response,
+};
+use crate::connection::{Connection, SerialConnection};
+use crate::errors::{InternalError, TockloaderError};
+use crate::CommandEraseApps;
+
+#[async_trait]
+impl CommandEraseApps for SerialConnection {
+    async fn erase_apps(&mut self, settings: &BoardSettings) -> Result<(), TockloaderError> {
+        if !self.is_open() {
+            return Err(InternalError::ConnectionNotOpen.into());
+        }
+        let stream = self.stream.as_mut().expect("Board must be open");
+
+        ping_bootloader_and_wait_for_response(stream).await?;
+
+        let pkt = (settings.start_address as u32).to_le_bytes().to_vec();
+        let (_, _) = issue_command(stream, Command::ErasePage, pkt, true, 0, Response::OK).await?;
+        Ok(())
+    }
+}

--- a/tockloader-lib/src/command_impl/serial/mod.rs
+++ b/tockloader-lib/src/command_impl/serial/mod.rs
@@ -1,3 +1,4 @@
+pub mod erase_apps;
 pub mod info;
 pub mod install;
 pub mod list;


### PR DESCRIPTION
### Pull Request Overview


This pull request adds ```erase-apps``` for serial


### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***erase-apps*** on ***microbit-v2***
- I tested with apps installed via tockloader and tockloader-rs.


### GitHub Issue


This pull request closes <[Implement erase-apps for serial #98 ](https://github.com/WyliodrinEmbeddedIoT/tockloader-rs/issues/98)>
