### PR TITLE
fix: corrected tbf parser values

### DIFF
--- a/tbf-parser/README.md
+++ b/tbf-parser/README.md
@@ -1,0 +1,17 @@
+# tbf-parser
+
+This document is a list of changes made to the original crate.
+
+## Changes:
+- `get_application_flags`
+    - Return flags of the application
+    - DELTA: Originally did not exist
+- `get_protected_trailer_size`
+    - Get the size of the protected trailer. This only returns the trailer size, WITHOUT the header. The app cannot write to this region.
+    - DELTA: Originally did not exist
+- `get_protected_region_size`
+    - Get the size in bytes of the protected region from the beginning of the process binary (start of the TBF header). The returned size includes the TBF Header. Only valid if this is an app.
+    - DELTA: Originally named `get_protected_size`, renamed to remove ambiguity.
+- `get_tbf_version` 
+    - Return the version of the Tock Binary Format
+    - DELTA: Originally did not exist

--- a/tbf-parser/tests/parse.rs
+++ b/tbf-parser/tests/parse.rs
@@ -16,8 +16,9 @@ fn simple_tbf() {
     dbg!(&header);
     assert!(header.enabled());
     assert_eq!(header.get_minimum_app_ram_size(), 4848);
-    assert_eq!(header.get_init_function_offset(), 41 + header_len as u32);
-    assert_eq!(header.get_protected_size(), header_len as u32);
+    assert_eq!(header.get_init_function_offset(), 41);
+    assert_eq!(header.get_protected_trailer_size(), 0);
+    assert_eq!(header.get_application_flags(), 1);
     assert_eq!(header.get_package_name().unwrap(), "_heart");
     assert_eq!(header.get_kernel_version().unwrap(), (2, 0));
 }
@@ -37,8 +38,9 @@ fn footer_sha256() {
     dbg!(&header);
     assert!(header.enabled());
     assert_eq!(header.get_minimum_app_ram_size(), 4848);
-    assert_eq!(header.get_init_function_offset(), 41 + header_len as u32);
-    assert_eq!(header.get_protected_size(), header_len as u32);
+    assert_eq!(header.get_init_function_offset(), 41);
+    assert_eq!(header.get_protected_trailer_size(), 0);
+    assert_eq!(header.get_application_flags(), 1);
     assert_eq!(header.get_package_name().unwrap(), "_heart");
     assert_eq!(header.get_kernel_version().unwrap(), (2, 0));
     let binary_offset = header.get_binary_end() as usize;
@@ -87,8 +89,9 @@ fn footer_rsa4096() {
     dbg!(&header);
     assert!(header.enabled());
     assert_eq!(header.get_minimum_app_ram_size(), 4612);
-    assert_eq!(header.get_init_function_offset(), 41 + header_len as u32);
-    assert_eq!(header.get_protected_size(), header_len as u32);
+    assert_eq!(header.get_init_function_offset(), 41);
+    assert_eq!(header.get_protected_trailer_size(), 0);
+    assert_eq!(header.get_application_flags(), 1);
     assert_eq!(header.get_package_name().unwrap(), "c_hello");
     assert_eq!(header.get_kernel_version().unwrap(), (2, 0));
     let binary_offset = header.get_binary_end() as usize;

--- a/tockloader-cli/src/display.rs
+++ b/tockloader-cli/src/display.rs
@@ -76,13 +76,13 @@ pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut 
         );
 
         println!(
-            " {BOLD_GREEN} Address in Flash: {RESET}{}",
-            system_details.appaddr.unwrap(),
+            " {BOLD_GREEN} Address in Flash: {RESET}{:#x}",
+            details.address,
         );
 
         println!(
             " {BOLD_GREEN}    TBF version:   {RESET}{}",
-            details.tbf_header.get_binary_version(),
+            details.tbf_header.get_tbf_version(),
         );
 
         println!(
@@ -96,11 +96,14 @@ pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut 
         );
 
         println!(
-            " {BOLD_GREEN}    checksum:      {RESET}{}",
+            " {BOLD_GREEN}    checksum:      {RESET}{:#x}",
             details.tbf_header.checksum(),
         );
 
-        println!(" {BOLD_GREEN}    flags:{RESET}");
+        println!(
+            " {BOLD_GREEN}    flags:         {RESET}{:#b}",
+            details.tbf_header.get_application_flags(),
+        );
         println!(
             " {BOLD_GREEN}        enabled:       {RESET}{}",
             details.tbf_header.enabled(),
@@ -111,55 +114,55 @@ pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut 
             details.tbf_header.sticky(),
         );
 
-        println!(" {BOLD_GREEN}    TVL: Main (1){RESET}");
+        println!(" {BOLD_GREEN}    TLV: Main (1){RESET}");
         println!(
-            " {BOLD_GREEN}        init_fn_offset:        {RESET}{}",
+            " {BOLD_GREEN}        init_fn_offset:           {RESET}{}",
             details.tbf_header.get_init_function_offset(),
         );
 
         println!(
-            " {BOLD_GREEN}        protected_size:        {RESET}{}",
-            details.tbf_header.get_protected_size(),
+            " {BOLD_GREEN}        protected_trailer_size:   {RESET}{}",
+            details.tbf_header.get_protected_trailer_size(),
         );
 
         println!(
-            " {BOLD_GREEN}        minimum_ram_size:      {RESET}{}",
+            " {BOLD_GREEN}        minimum_ram_size:         {RESET}{}",
             details.tbf_header.get_minimum_app_ram_size(),
         );
 
-        println!(" {BOLD_GREEN}    TVL: Program (9){RESET}");
+        println!(" {BOLD_GREEN}    TLV: Program (9){RESET}");
         println!(
-            " {BOLD_GREEN}        init_fn_offset:        {RESET}{}",
+            " {BOLD_GREEN}        init_fn_offset:           {RESET}{}",
             details.tbf_header.get_init_function_offset(),
         );
 
         println!(
-            " {BOLD_GREEN}        protected_size:        {RESET}{}",
-            details.tbf_header.get_protected_size(),
+            " {BOLD_GREEN}        protected_trailer_size:   {RESET}{}",
+            details.tbf_header.get_protected_trailer_size(),
         );
 
         println!(
-            " {BOLD_GREEN}        minimum_ram_size:      {RESET}{}",
+            " {BOLD_GREEN}        minimum_ram_size:         {RESET}{}",
             details.tbf_header.get_minimum_app_ram_size(),
         );
 
         println!(
-            " {BOLD_GREEN}        binary_end_offset:     {RESET}{}",
+            " {BOLD_GREEN}        binary_end_offset:        {RESET}{}",
             details.tbf_header.get_binary_end(),
         );
 
         println!(
-            " {BOLD_GREEN}        app_version:           {RESET}{}",
+            " {BOLD_GREEN}        app_version:              {RESET}{}",
             details.tbf_header.get_binary_version(),
         );
 
-        println!(" {BOLD_GREEN}    TVL: Package Name (3){RESET}");
+        println!(" {BOLD_GREEN}    TLV: Package Name (3){RESET}");
         println!(
             " {BOLD_GREEN}        package_name:          {RESET}{}",
             details.tbf_header.get_package_name().unwrap(),
         );
 
-        println!(" {BOLD_GREEN}    TVL: Kernel Version (8){RESET}");
+        println!(" {BOLD_GREEN}    TLV: Kernel Version (8){RESET}");
         println!(
             " {BOLD_GREEN}        kernel_major:          {RESET}{}",
             details.tbf_header.get_kernel_version().unwrap().0,
@@ -183,7 +186,7 @@ pub async fn print_info(app_details: &mut [AppAttributes], system_details: &mut 
         println!(" {BOLD_GREEN}            footer_size:       {RESET}{total_footer_size}");
 
         for (j, footer_details) in details.tbf_footers.iter().enumerate() {
-            println!(" {BOLD_GREEN}    Footer [{j}] TVL: Credentials{RESET}");
+            println!(" {BOLD_GREEN}    Footer [{j}] TLV: Credentials{RESET}");
 
             println!(
                 " {BOLD_GREEN}        Type:                  {RESET}{}",

--- a/tockloader-lib/src/attributes/app_attributes.rs
+++ b/tockloader-lib/src/attributes/app_attributes.rs
@@ -19,6 +19,7 @@ use crate::errors::{TockError, TockloaderError};
 /// See also <https://book.tockos.org/doc/tock_binary_format>
 #[derive(Debug)]
 pub struct AppAttributes {
+    pub address: u64,
     pub tbf_header: TbfHeader,
     pub tbf_footers: Vec<TbfFooter>,
 }
@@ -41,8 +42,13 @@ impl TbfFooter {
 // TODO(george-cosma): Could take advantages of the trait rework
 
 impl AppAttributes {
-    pub(crate) fn new(header_data: TbfHeader, footers_data: Vec<TbfFooter>) -> AppAttributes {
+    pub(crate) fn new(
+        address: u64,
+        header_data: TbfHeader,
+        footers_data: Vec<TbfFooter>,
+    ) -> AppAttributes {
         AppAttributes {
+            address,
             tbf_header: header_data,
             tbf_footers: footers_data,
         }
@@ -150,7 +156,7 @@ impl AppAttributes {
                 footer_offset += footer_info.1 + 4;
             }
 
-            let details: AppAttributes = AppAttributes::new(header, footers);
+            let details: AppAttributes = AppAttributes::new(appaddr, header, footers);
 
             apps_details.insert(apps_counter, details);
             apps_counter += 1;
@@ -289,7 +295,7 @@ impl AppAttributes {
                 footer_offset += footer_info.1 + 4;
             }
 
-            let details: AppAttributes = AppAttributes::new(header, footers);
+            let details: AppAttributes = AppAttributes::new(appaddr, header, footers);
 
             apps_details.insert(apps_counter, details);
             apps_counter += 1;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the values provided by the TBF Parser. ```init_fn_offset``` and ```protected_size``` also had the ```header_size``` added to them. In the python version version, the ```header_size``` is not added to them.

The ```TBF Version``` was wrongly obtained using the ```get_binary_version```, which is different from the correct one, found in the base header.


### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- [x] ***info*** on ***microbit-v2*** using **tockloader-rs**
- [x] ***tockloader info*** on ***microbit-v2*** 


### GitHub Issue


This pull request closes [BUG: Differences in init_fn_size and protected_size fields for app TBF #70](https://github.com/WyliodrinEmbeddedIoT/tockloader-rs/issues/70)
