### PR TITLE
feat: add support for nrf52840, make clippy error only on main crate

### DIFF
--- a/tockloader-cli/src/cli.rs
+++ b/tockloader-cli/src/cli.rs
@@ -32,7 +32,7 @@ fn get_subcommands() -> Vec<Command> {
             .about("Open a terminal to receive UART data")
             .args(get_channel_args())
             .args([
-                // TODO(george-cosma): Change default to pconsole when new format is implemented and adopted into tock
+                // TODO(eva-cosma): Change default to pconsole when new format is implemented and adopted into tock
                 arg!(--protocol <PROTOCOL> "Choose between legacy and pconsole protocol")
                     .default_value("legacy")
                     .value_parser(["legacy", "pconsole"]),

--- a/tockloader-cli/src/known_boards.rs
+++ b/tockloader-cli/src/known_boards.rs
@@ -2,6 +2,7 @@
 pub enum KnownBoardNames {
     NucleoF4,
     MicrobitV2,
+    Nrf52840dk,
 }
 
 impl KnownBoardNames {
@@ -9,6 +10,7 @@ impl KnownBoardNames {
         match name {
             "nucleo-f4" => Some(Self::NucleoF4),
             "microbit-v2" => Some(Self::MicrobitV2),
+            "nrf52840dk" => Some(Self::Nrf52840dk),
             _ => None,
         }
     }
@@ -17,12 +19,17 @@ impl KnownBoardNames {
         match &self {
             KnownBoardNames::NucleoF4 => "nucleo-f4",
             KnownBoardNames::MicrobitV2 => "microbit-v2",
+            KnownBoardNames::Nrf52840dk => "nrf52840dk",
         }
     }
 }
 
 pub fn list_known_board_names() -> Vec<KnownBoardNames> {
-    vec![KnownBoardNames::NucleoF4, KnownBoardNames::MicrobitV2]
+    vec![
+        KnownBoardNames::NucleoF4,
+        KnownBoardNames::MicrobitV2,
+        KnownBoardNames::Nrf52840dk,
+    ]
 }
 
 #[cfg(test)]
@@ -38,7 +45,11 @@ mod tests {
 
     #[test]
     fn list_known_boards_updated() {
-        let backup_list = vec![KnownBoardNames::NucleoF4, KnownBoardNames::MicrobitV2];
+        let backup_list = vec![
+            KnownBoardNames::NucleoF4,
+            KnownBoardNames::MicrobitV2,
+            KnownBoardNames::Nrf52840dk,
+        ];
 
         assert_eq!(list_known_board_names(), backup_list, "If this fails it means that you likely forgot to update `list_known_boards`, and subsequently the `list_known_boards_updated` test");
     }

--- a/tockloader-cli/src/main.rs
+++ b/tockloader-cli/src/main.rs
@@ -94,6 +94,9 @@ fn get_known_board(user_options: &ArgMatches) -> Option<Box<dyn KnownBoard>> {
             KnownBoardNames::MicrobitV2 => {
                 Box::new(tockloader_lib::known_boards::MicrobitV2) as Box<dyn KnownBoard>
             }
+            KnownBoardNames::Nrf52840dk => {
+                Box::new(tockloader_lib::known_boards::Nrf52840dk) as Box<dyn KnownBoard>
+            }
         }
     })
 }

--- a/tockloader-lib/src/attributes/app_attributes.rs
+++ b/tockloader-lib/src/attributes/app_attributes.rs
@@ -39,7 +39,7 @@ impl TbfFooter {
     }
 }
 
-// TODO(george-cosma): Could take advantages of the trait rework
+// TODO(eva-cosma): Could take advantages of the trait rework
 
 impl AppAttributes {
     pub(crate) fn new(

--- a/tockloader-lib/src/attributes/decode.rs
+++ b/tockloader-lib/src/attributes/decode.rs
@@ -63,7 +63,7 @@ pub(crate) fn decode_attribute(step: &[u8]) -> Option<DecodedAttribute> {
     Some(DecodedAttribute::new(key, value))
 }
 
-// TODO(george-cosma) replace this function with std::str::from_utf8(...). It
+// TODO(eva-cosma) replace this function with std::str::from_utf8(...). It
 // does the same thing.
 
 /// Transform a byte-slice into a String.

--- a/tockloader-lib/src/attributes/system_attributes.rs
+++ b/tockloader-lib/src/attributes/system_attributes.rs
@@ -122,7 +122,7 @@ impl SystemAttributes {
             }
         }
 
-        // TODO(george-cosma): separate kernel attributes from kernel flags.
+        // TODO(eva-cosma): separate kernel attributes from kernel flags.
 
         let address = 0x40E;
         let mut buf = [0u8; 8];
@@ -241,7 +241,7 @@ impl SystemAttributes {
             }
         }
 
-        // TODO(george-cosma): separate kernel attributes from kernel flags.
+        // TODO(eva-cosma): separate kernel attributes from kernel flags.
 
         let mut pkt = (0x40E_u32).to_le_bytes().to_vec();
         let length = (8_u16).to_le_bytes().to_vec();

--- a/tockloader-lib/src/board_settings.rs
+++ b/tockloader-lib/src/board_settings.rs
@@ -3,7 +3,7 @@ pub struct BoardSettings {
     pub start_address: u64,
 }
 
-// TODO(george-cosma): Does a default implementation make sense for this? Is a
+// TODO(eva-cosma): Does a default implementation make sense for this? Is a
 // 'None' architechture a sane idea?
 impl Default for BoardSettings {
     fn default() -> Self {

--- a/tockloader-lib/src/bootloader_serial.rs
+++ b/tockloader-lib/src/bootloader_serial.rs
@@ -222,7 +222,7 @@ pub async fn issue_command(
 
         // De-escape and add array of read in the bytes
 
-        // TODO(george-cosma): Extract this into a function and unit test this.
+        // TODO(eva-cosma): Extract this into a function and unit test this.
         let mut i = 0;
         while i < input.len() {
             if i + 1 < input.len() && input[i] == ESCAPE_CHAR && input[i + 1] == ESCAPE_CHAR {

--- a/tockloader-lib/src/command_impl/probers/info.rs
+++ b/tockloader-lib/src/command_impl/probers/info.rs
@@ -21,7 +21,7 @@ impl CommandInfo for ProbeRSConnection {
 
         let mut core = session.core(self.target_info.core)?;
 
-        // TODO(george-cosma): extract these informations without bootloader
+        // TODO(eva-cosma): extract these informations without bootloader
         let system_attributes = SystemAttributes::read_system_attributes_probe(&mut core)?;
         let app_attributes =
             AppAttributes::read_apps_data_probe(&mut core, settings.start_address)?;

--- a/tockloader-lib/src/command_impl/probers/install.rs
+++ b/tockloader-lib/src/command_impl/probers/install.rs
@@ -23,12 +23,12 @@ impl CommandInstall for ProbeRSConnection {
 
         let mut core = session.core(self.target_info.core)?;
 
-        // TODO(george-cosma): extract these informations without bootloader
-        // TODO(george-cosma): extract board name and kernel version to verify app compatability
+        // TODO(eva-cosma): extract these informations without bootloader
+        // TODO(eva-cosma): extract board name and kernel version to verify app compatability
 
         let mut address = settings.start_address;
 
-        // TODO(george-cosma): double-check/rework this
+        // TODO(eva-cosma): double-check/rework this
 
         // Read a block of 200 8-bit words// Loop to check if there are another apps installed
         loop {
@@ -46,8 +46,8 @@ impl CommandInstall for ProbeRSConnection {
             address += whole_len as u64;
         }
 
-        // TODO(george-cosma): extract arch(?)
-        // TODO(george-cosma): THIS IS NOT A TOCK ERROR, this is an error due to invalid board settings.
+        // TODO(eva-cosma): extract arch(?)
+        // TODO(eva-cosma): THIS IS NOT A TOCK ERROR, this is an error due to invalid board settings.
         let arch = settings
             .arch
             .as_ref()
@@ -69,7 +69,7 @@ impl CommandInstall for ProbeRSConnection {
             (address, 0)
         };
 
-        // TODO(george-cosma): This point MIGHT mark a good point to split
+        // TODO(eva-cosma): This point MIGHT mark a good point to split
         // this function (for probe-rs).
 
         // At this point we no longer need to hold the probe-rs connection
@@ -78,7 +78,7 @@ impl CommandInstall for ProbeRSConnection {
 
         // Make sure the binary is a multiple of the page size by padding 0xFFs
 
-        // TODO(george-cosma): check if the page-size differs + support
+        // TODO(eva-cosma): check if the page-size differs + support
         // multiple types of page sizes. Possibly make page size a board
         // setting.
         let page_size = 512;
@@ -152,7 +152,7 @@ impl CommandInstall for ProbeRSConnection {
             options.keep_unwritten_bytes = true;
 
             // Finally, the data can be programmed
-            // TODO(george-cosma): Can we move this outside the loop? Commit once?
+            // TODO(eva-cosma): Can we move this outside the loop? Commit once?
             loader.commit(session, options)?;
         }
 

--- a/tockloader-lib/src/known_boards.rs
+++ b/tockloader-lib/src/known_boards.rs
@@ -50,3 +50,25 @@ impl KnownBoard for MicrobitV2 {
         }
     }
 }
+
+pub struct Nrf52840dk;
+
+impl KnownBoard for Nrf52840dk {
+    fn serial_target_info(&self) -> SerialTargetInfo {
+        SerialTargetInfo::default()
+    }
+
+    fn probe_target_info(&self) -> ProbeTargetInfo {
+        ProbeTargetInfo {
+            chip: "nRF52840_xxAA".to_string(),
+            core: 0,
+        }
+    }
+
+    fn get_settings(&self) -> BoardSettings {
+        BoardSettings {
+            arch: Some("cortex-m4".to_string()),
+            start_address: 0x00040000,
+        }
+    }
+}

--- a/tockloader-lib/src/lib.rs
+++ b/tockloader-lib/src/lib.rs
@@ -29,11 +29,11 @@ pub fn list_serial_ports() -> Result<Vec<SerialPortInfo>, TockloaderError> {
     tokio_serial::available_ports().map_err(|e| TockloaderError::Serial(e.into()))
 }
 
-// TODO(george-cosma): Examine if we need to split these functions into smaller
+// TODO(eva-cosma): Examine if we need to split these functions into smaller
 // parts (reading - processing - writing) for mocking. Could also involve adding
 // functions to the proposed 'Connection' trait.
 
-// TODO(george-cosma): General housekeeping in these functions.
+// TODO(eva-cosma): General housekeeping in these functions.
 
 #[async_trait]
 pub trait CommandList {

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -11,4 +11,11 @@ fi
 # TODO: What arguments do we want to pass to clippy?
 CLIPPY_ARGS="-D warnings"
 
-cargo clippy -- $CLIPPY_ARGS
+# Clippy entire workspace, havivng warnings be treated normally
+echo "Running clippy on entire workspace, treating warnings as warnings..."
+cargo clippy 
+
+# However, for tockloader and tockloader-lib, we will treat them as errors.
+echo "Running clippy on tockloader and tockloader-lib, treating warnings as errors..."
+cargo clippy -p tockloader -- $CLIPPY_ARGS
+cargo clippy -p tockloader-lib -- $CLIPPY_ARGS


### PR DESCRIPTION
### Pull Request Overview

Adds support for the nrf52840 and make clippy error on warnings only on tockloader and tockloader-lib

### TODO or Help Wanted

N/A

### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
- No test needed

### GitHub Issue

None