### PR TITLE
Fix system attribute addressing

### DIFF
--- a/tockloader-lib/Cargo.toml
+++ b/tockloader-lib/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1.32.0", features = ["full"] }
 tokio-serial = { version = "5.4.4", features = ["libudev"] }
 probe-rs = "0.24.0"
 tbf-parser = { path = "../tbf-parser" }
-utf8-decode = "1.0.1"
 byteorder = "1.5.0"
 tar = "0.4.41"
 bytes = "1.7.1"

--- a/tockloader-lib/src/attributes/decode.rs
+++ b/tockloader-lib/src/attributes/decode.rs
@@ -17,66 +17,49 @@ pub struct DecodedAttribute {
 }
 
 impl DecodedAttribute {
+    /// Total size of one encoded attribute is: 8 byte key + 1 byte value
+    /// length + up to 55 byte value
+    pub(crate) const ENCODED_LEN: usize = 64;
+    /// Maximum allowed length of an attribute's value field: 55 bytes remain
+    /// (bytes 9–63) after the 8-byte key and 1-byte length fields.
+    const ATTRIBUTE_LEN: u8 = 55;
     pub(crate) fn new(decoded_key: String, decoded_value: String) -> DecodedAttribute {
         DecodedAttribute {
             key: decoded_key,
             value: decoded_value,
         }
     }
-}
 
-/// Internal function used to decode the raw data into a [DecodedAttribute].
-///
-/// # Params
-/// - `step` - byte array of at least 64 bytes.
-///
-/// # Returns
-/// - `None` for an invalid property (invalid value length or invalid utf-8
-///   data).
-/// - `Some(_)` otherwise
-pub(crate) fn decode_attribute(step: &[u8]) -> Option<DecodedAttribute> {
-    let raw_key = &step[0..8];
+    /// Decode raw data into a [DecodedAttribute].
+    ///
+    /// # Params
+    /// - `encoded` - byte array of at least 64 bytes.
+    ///
+    /// # Returns
+    /// - `None` for an invalid property (invalid value length or invalid utf-8
+    ///   data).
+    /// - `Some(_)` otherwise
+    pub fn decode(encoded: &[u8]) -> Option<DecodedAttribute> {
+        let raw_key = &encoded[0..8];
 
-    let decoder_key = utf8_decode::Decoder::new(raw_key.iter().cloned());
+        let key = std::str::from_utf8(raw_key)
+            .ok()?
+            .trim_end_matches('\0')
+            .to_string();
 
-    let mut key = String::new();
-    for n in decoder_key {
-        key.push(n.expect("Error getting key for attributes."));
+        let vlen = encoded[8];
+
+        if vlen > DecodedAttribute::ATTRIBUTE_LEN || vlen == 0 {
+            return None;
+        }
+
+        let raw_value = &encoded[9..(9 + vlen as usize)];
+
+        let value = std::str::from_utf8(raw_value)
+            .ok()?
+            .trim_end_matches('\0')
+            .to_string();
+
+        Some(DecodedAttribute::new(key, value))
     }
-
-    key = key.trim_end_matches('\0').to_string();
-    let vlen = step[8];
-
-    if vlen > 55 || vlen == 0 {
-        return None;
-    }
-    let raw_value = &step[9..(9 + vlen as usize)];
-    let decoder_value = utf8_decode::Decoder::new(raw_value.iter().cloned());
-
-    let mut value = String::new();
-
-    for n in decoder_value {
-        value.push(n.expect("Error getting key for attributes."));
-    }
-
-    value = value.trim_end_matches('\0').to_string();
-    Some(DecodedAttribute::new(key, value))
-}
-
-// TODO(eva-cosma) replace this function with std::str::from_utf8(...). It
-// does the same thing.
-
-/// Transform a byte-slice into a String.
-///
-/// # Panics
-///
-/// This code panics if the given bytes are not utf-8 representable
-pub(crate) fn bytes_to_string(raw: &[u8]) -> String {
-    let decoder = utf8_decode::Decoder::new(raw.iter().cloned());
-
-    let mut string = String::new();
-    for n in decoder {
-        string.push(n.expect("Error getting key for attributes."));
-    }
-    string
 }

--- a/tockloader-lib/src/attributes/system_attributes.rs
+++ b/tockloader-lib/src/attributes/system_attributes.rs
@@ -4,10 +4,9 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use super::decode::DecodedAttribute;
 use crate::errors::{AttributeParseError, TockError, TockloaderError};
 use crate::IO;
-
-use super::decode::{bytes_to_string, decode_attribute};
 
 /// This structure contains all relevant information about board that is stored
 /// in the bootloader ROM.
@@ -48,12 +47,29 @@ impl SystemAttributes {
         }
     }
 
-    /// Read system attributes using a generalized connection. A bootloader must be
-    /// present on this board for this function to work properly.
-    ///
+    /// Check if the bootloader is present on the version of Tock
+    pub(crate) async fn bootloader_is_present(
+        conn: &mut dyn IO,
+        flash_start_address: u64,
+    ) -> Result<bool, TockloaderError> {
+        // If a bootloader is present, the start of 0x400 will read
+        // "TOCKBOOTLOADER", which is exactly 14 bytes long, so we'll read
+        // 14 bytes starting from 0x400.
+        let flag = conn.read(flash_start_address + 0x400, 14).await?;
+        if flag == "TOCKBOOTLOADER".as_bytes() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Read system and kernel attributes.
+    /// System attributes are read only if the board has
+    /// a bootloader present.
     /// # Parameters
-    /// - `conn` : Either a SerialConnection or a ProbeRSConnection
-    ///
+    /// - `conn` : Either a SerialConnection or a ProbeRSConnection.
+    /// - `flash_address` : The start of flash memory.
+    /// - `start_address` : The start of User Space Applications in flash memory.
     /// # Returns
     /// - Ok(result): if attributes were read successfully
     /// - Err(TockloaderError::MisconfiguredBoard): if no start address is found or valid
@@ -62,74 +78,62 @@ impl SystemAttributes {
     /// - Err(TockloaderError::SerialReadError): if reading fails on Serial
     pub(crate) async fn read_system_attributes(
         conn: &mut dyn IO,
+        flash_start_address: u64,
+        app_start_address: u64,
     ) -> Result<SystemAttributes, TockloaderError> {
         let mut result = SystemAttributes::new();
-        // System attributes start at 0x600 and up to 0x9FF. See:
+        // System attributes start at an offset of 0x600 and up to 0x9FF. See:
         // https://book.tockos.org/doc/memory_layout#flash-1
-        let address = 0x600;
+        //
+        let address = flash_start_address + 0x600;
 
         let buf = conn.read(address, 64 * 16).await?;
 
-        let mut data = buf.chunks(64);
+        let has_bootloader = Self::bootloader_is_present(conn, flash_start_address).await?;
 
-        for current_slot in 0..data.len() {
-            let slot_data = match data.next() {
-                Some(data) => data,
-                None => break,
-            };
-
-            // If the attribute chunk was successfully decoded, assign its value
-            // to the corresponding field in `result` based on the index:
-            // - 0 = board name,
-            // - 1 = architecture,
-            // - 2 = application start address (parsed from hex string),
-            // - 3 = boot hash, _ = invalid or missing data is skipped.
-            // NOTE: this can also be done by looping directly through the key attributes.
-            if let Some(decoded_attributes) = decode_attribute(slot_data) {
-                match current_slot {
-                    0 => {
-                        result.board = Some(decoded_attributes.value.to_string());
-                    }
-                    1 => {
-                        result.arch = Some(decoded_attributes.value.to_string());
-                    }
-                    2 => {
-                        // Parse hex string like "0x40000" into actual u64 value
-                        result.appaddr = Some(
-                            u64::from_str_radix(
-                                decoded_attributes
-                                    .value
-                                    .to_string()
-                                    .trim_start_matches("0x"),
-                                16,
-                            )
-                            .map_err(|e| {
-                                TockError::AttributeParsing(AttributeParseError::InvalidNumber(e))
-                            })?,
-                        );
-                    }
-                    3 => {
-                        result.boothash = Some(decoded_attributes.value.to_string());
-                    }
-                    _ => {}
-                }
-            } else {
-                continue;
+        if !has_bootloader {
+            // TODO(K-Nicolas-10): Chain: CLI arguments -> hardcoded start_address -> calculate from kernel app start address
+            result.appaddr = Some(app_start_address);
+        } else {
+            let mut attribute_chunks = buf.chunks_exact(DecodedAttribute::ENCODED_LEN);
+            // We always read 16 * 64 bytes so we won't panic
+            if let Some(board) = attribute_chunks.next().and_then(DecodedAttribute::decode) {
+                result.board = Some(board.value);
             }
+
+            if let Some(arch) = attribute_chunks.next().and_then(DecodedAttribute::decode) {
+                result.arch = Some(arch.value);
+            }
+
+            if let Some(appaddr) = attribute_chunks.next().and_then(DecodedAttribute::decode) {
+                result.appaddr = Some(
+                    u64::from_str_radix(appaddr.value.trim_start_matches("0x"), 16).map_err(
+                        |e| TockError::AttributeParsing(AttributeParseError::InvalidNumber(e)),
+                    )?,
+                );
+            }
+
+            if let Some(boothash) = attribute_chunks.next().and_then(DecodedAttribute::decode) {
+                result.boothash = Some(boothash.value);
+            }
+
+            // At this address lives the version of the bootloader we are using.
+            // Trying to read this when no bootloader is present will result in a panic.
+            // So we first verify if we have a bootloader, if not we just skip this and
+            // return None for the bootloader version.
+            let address = flash_start_address + 0x40E;
+
+            let buf = conn.read(address, 8).await?;
+
+            let string = String::from_utf8(buf.to_vec())
+                .map_err(|e| TockError::AttributeParsing(AttributeParseError::InvalidString(e)))?;
+
+            let string = string.trim_matches(char::from(0));
+
+            result.bootloader_version = Some(string.to_owned());
         }
 
         // TODO(eva-cosma): separate kernel attributes from kernel flags.
-
-        let address = 0x40E;
-
-        let buf = conn.read(address, 8).await?;
-
-        let string = String::from_utf8(buf.to_vec())
-            .map_err(|e| TockError::AttributeParsing(AttributeParseError::InvalidString(e)))?;
-
-        let string = string.trim_matches(char::from(0));
-
-        result.bootloader_version = Some(string.to_owned());
 
         // The 100 bytes prior to the application start address are reserved for the kernel attributes and flags
         let kernel_attr_addr = result
@@ -138,7 +142,13 @@ impl SystemAttributes {
             - 100;
         let kernel_attr_binary = conn.read(kernel_attr_addr, 100).await?;
 
-        let sentinel = bytes_to_string(&kernel_attr_binary[96..100]);
+        let sentinel = std::str::from_utf8(&kernel_attr_binary[96..100])
+            .map_err(|_| TockError::AttributeParsing(AttributeParseError::InvalidSentinel))?
+            .to_string();
+
+        if sentinel != "TOCK" {
+            return Err(TockError::AttributeParsing(AttributeParseError::InvalidSentinel).into());
+        }
         let kernel_version = LittleEndian::read_uint(&kernel_attr_binary[95..96], 1);
 
         let app_memory_len = LittleEndian::read_u32(&kernel_attr_binary[84..92]);

--- a/tockloader-lib/src/board_settings.rs
+++ b/tockloader-lib/src/board_settings.rs
@@ -1,7 +1,10 @@
 #[derive(Clone)]
 pub struct BoardSettings {
     pub arch: Option<String>,
-    pub start_address: u64,
+    /// Previously named 'flash_address' in the python version of tockloader
+    pub flash_start_address: u64,
+    /// Previously named `start_address` in the python version of tockloader
+    pub app_start_address: u64,
     pub page_size: u64,
     pub ram_start_address: u64,
 }
@@ -12,7 +15,8 @@ impl Default for BoardSettings {
     fn default() -> Self {
         Self {
             arch: None,
-            start_address: 0x30000,
+            flash_start_address: 0x00000,
+            app_start_address: 0x40000,
             page_size: 512,
             ram_start_address: 0x20000000,
         }

--- a/tockloader-lib/src/bootloader_serial.rs
+++ b/tockloader-lib/src/bootloader_serial.rs
@@ -156,7 +156,6 @@ async fn write_bytes(
     .map_err(|_| TockError::BootloaderTimeout)?
 }
 
-#[allow(dead_code)]
 pub async fn ping_bootloader_and_wait_for_response(
     port: &mut SerialStream,
 ) -> Result<(), TockloaderError> {

--- a/tockloader-lib/src/command_impl/erase_apps.rs
+++ b/tockloader-lib/src/command_impl/erase_apps.rs
@@ -7,6 +7,7 @@ use crate::{CommandEraseApps, IO};
 #[async_trait]
 impl CommandEraseApps for TockloaderConnection {
     async fn erase_apps(&mut self) -> Result<(), TockloaderError> {
-        self.write(self.get_settings().start_address, &[0u8]).await
+        self.write(self.get_settings().app_start_address, &[0u8])
+            .await
     }
 }

--- a/tockloader-lib/src/command_impl/info.rs
+++ b/tockloader-lib/src/command_impl/info.rs
@@ -8,8 +8,8 @@ use crate::{CommandInfo, IOCommands};
 #[async_trait]
 impl CommandInfo for TockloaderConnection {
     async fn info(&mut self) -> Result<GeneralAttributes, TockloaderError> {
-        let installed_apps = self.read_installed_apps().await.unwrap();
-        let system_atributes = self.read_system_attributes().await.unwrap();
+        let installed_apps = self.read_installed_apps().await?;
+        let system_atributes = self.read_system_attributes().await?;
         Ok(GeneralAttributes::new(system_atributes, installed_apps))
     }
 }

--- a/tockloader-lib/src/command_impl/install.rs
+++ b/tockloader-lib/src/command_impl/install.rs
@@ -21,7 +21,7 @@ impl CommandInstall for TockloaderConnection {
         // obtain the binaries in a vector
         let mut app_binaries: Vec<Vec<u8>> = Vec::new();
 
-        let mut address = settings.start_address;
+        let mut address = settings.app_start_address;
         for app in app_attributes_list.iter() {
             app_binaries.push(
                 self.read(address, app.tbf_header.total_size() as usize)
@@ -45,7 +45,7 @@ impl CommandInstall for TockloaderConnection {
 
         log::debug!("pkt len {}", pkt.len());
         // write the pkt
-        let _ = self.write(settings.start_address, &pkt).await;
+        let _ = self.write(settings.app_start_address, &pkt).await;
         Ok(())
     }
 }

--- a/tockloader-lib/src/command_impl/probers/io.rs
+++ b/tockloader-lib/src/command_impl/probers/io.rs
@@ -45,7 +45,7 @@ impl IOCommands for ProbeRSConnection {
         if !self.is_open() {
             return Err(InternalError::ConnectionNotOpen.into());
         }
-        let start_address = self.get_settings().start_address;
+        let start_address = self.get_settings().app_start_address;
         AppAttributes::read_apps_data(self, start_address).await
     }
 
@@ -53,7 +53,10 @@ impl IOCommands for ProbeRSConnection {
         if !self.is_open() {
             return Err(InternalError::ConnectionNotOpen.into());
         }
-        let system_attributes = SystemAttributes::read_system_attributes(self).await?;
+        let flash_address = self.get_settings().flash_start_address;
+        let start_address = self.get_settings().app_start_address;
+        let system_attributes =
+            SystemAttributes::read_system_attributes(self, flash_address, start_address).await?;
         Ok(system_attributes)
     }
 }

--- a/tockloader-lib/src/command_impl/reshuffle_apps.rs
+++ b/tockloader-lib/src/command_impl/reshuffle_apps.rs
@@ -98,11 +98,11 @@ impl TockApp {
 
         if header.get_fixed_address_flash().is_some() {
             // addr = align_down(addr as u64) as u32;
-            // if addr < settings.start_address as u32 {
+            // if addr < settings.app_start_address as u32 {
             //     // this rust app should not be here
             //     panic!(
-            //         "This rust app starts at {addr:#x}, while the board's start_address is {:#x}",
-            //         settings.start_address
+            //         "This rust app starts at {addr:#x}, while the board's app_start_address is {:#x}",
+            //         settings.app_start_address
             //     )
             // }
             // turns out that fixed address is a loosely-used term, address has to be aligned down to a multiple of 1024 bytes
@@ -324,7 +324,7 @@ pub fn reshuffle_apps(
                 let insert_size = c_app.size;
 
                 if reordered_apps.is_empty() {
-                    reordered_apps.push(c_app.as_index(None, settings.start_address));
+                    reordered_apps.push(c_app.as_index(None, settings.app_start_address));
 
                     continue;
                 }
@@ -394,7 +394,7 @@ pub fn reshuffle_apps(
                             installed: false,
                             idx: None,
                             ram_address: None,
-                            address: settings.start_address + insert_size,
+                            address: settings.app_start_address + insert_size,
                             size: needed_padding,
                         });
                         reordered_apps.push(c_app.as_index(None, gap_start + needed_padding));
@@ -511,7 +511,8 @@ mod tests {
     fn install_new_c_app() {
         let settings: &BoardSettings = &BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         };
@@ -568,7 +569,8 @@ mod tests {
     fn install_new_rust_app() {
         let settings: &BoardSettings = &BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         };
@@ -604,7 +606,8 @@ mod tests {
     fn install_more_rust_apps() {
         let settings: &BoardSettings = &BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         };
@@ -678,7 +681,8 @@ mod tests {
     fn insert_c_app_between_rust_apps() {
         let settings: &BoardSettings = &BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         };

--- a/tockloader-lib/src/command_impl/serial/io.rs
+++ b/tockloader-lib/src/command_impl/serial/io.rs
@@ -71,7 +71,7 @@ impl IOCommands for SerialConnection {
 
         ping_bootloader_and_wait_for_response(stream).await?;
 
-        let start_address = self.get_settings().start_address;
+        let start_address = self.get_settings().app_start_address;
 
         AppAttributes::read_apps_data(self, start_address).await
     }
@@ -84,7 +84,10 @@ impl IOCommands for SerialConnection {
 
         ping_bootloader_and_wait_for_response(stream).await?;
 
-        let system_attributes = SystemAttributes::read_system_attributes(self).await?;
+        let flash_address = self.get_settings().flash_start_address;
+        let start_address = self.get_settings().app_start_address;
+        let system_attributes =
+            SystemAttributes::read_system_attributes(self, flash_address, start_address).await?;
         Ok(system_attributes)
     }
 }

--- a/tockloader-lib/src/errors.rs
+++ b/tockloader-lib/src/errors.rs
@@ -103,12 +103,16 @@ pub enum TockError {
 
 /// Represents errors that can occur while parsing attributes.
 #[derive(Debug, Error)]
+#[allow(clippy::enum_variant_names)]
 pub enum AttributeParseError {
     #[error("Expected attribute to be a valid number. Inner: {0}")]
     InvalidNumber(#[from] std::num::ParseIntError),
 
     #[error("Expected attribute to be a valid string. Inner: {0}")]
     InvalidString(#[from] std::string::FromUtf8Error),
+
+    #[error("Expected sentinel to be TOCK")]
+    InvalidSentinel,
 }
 
 /// Represents internal violations of assumptions, or inconsistent state. It

--- a/tockloader-lib/src/known_boards.rs
+++ b/tockloader-lib/src/known_boards.rs
@@ -24,7 +24,8 @@ impl KnownBoard for NucleoF4 {
     fn get_settings(&self) -> BoardSettings {
         BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x08040000,
+            flash_start_address: 0x08000000,
+            app_start_address: 0x08040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         }
@@ -48,7 +49,8 @@ impl KnownBoard for MicrobitV2 {
     fn get_settings(&self) -> BoardSettings {
         BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 512,
             ram_start_address: 0x20000000,
         }
@@ -72,7 +74,8 @@ impl KnownBoard for Nrf52840dk {
     fn get_settings(&self) -> BoardSettings {
         BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x00040000,
+            flash_start_address: 0x00000000,
+            app_start_address: 0x00040000,
             page_size: 4096,
             ram_start_address: 0x20008000,
         }
@@ -96,7 +99,8 @@ impl KnownBoard for NucleoU545ReQ {
     fn get_settings(&self) -> BoardSettings {
         BoardSettings {
             arch: Some("cortex-m4".to_string()),
-            start_address: 0x08000000,
+            flash_start_address: 0x08000000,
+            app_start_address: 0x08040000,
             page_size: 8192,
             ram_start_address: 0x20000000,
         }

--- a/tockloader-lib/src/tabs/tab.rs
+++ b/tockloader-lib/src/tabs/tab.rs
@@ -96,7 +96,7 @@ impl Tab {
             if flash != 0
                 && ram != 0
                 && arch.starts_with(settings.arch.as_ref().unwrap())
-                && flash >= settings.start_address
+                && flash >= settings.app_start_address
             {
                 log::info!("rust, pushed arch {arch}, flash {flash:#x}, ram {ram:#x}");
                 compatible_tbfs.push(Some((flash, ram)));


### PR DESCRIPTION
### Pull Request Overview

This pull request:
-Adds the Nucleo U545RE-Q Board.
-Adds start address field for known boards.
-Fixes info/erase-apps commands on boards that don't have a bootloader by removing the reading of system attributes(which do not have exist if you don't have a bootloader).
-Change bytes_to_string function to standard library function.


### Checks

<!--
Please tick off what you did, and specify what features you've tested on hardware.
-->

#### Using Rust tooling
- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Ran `cargo test`
- [x] Ran `cargo build`

#### Features tested:
erase,info,list,listen
