### PR TITLE
Install improvement

### DIFF
--- a/tockloader-cli/src/cli.rs
+++ b/tockloader-cli/src/cli.rs
@@ -70,6 +70,8 @@ fn get_app_args() -> Vec<clap::Arg> {
         arg!(-a --"app-address" <ADDRESS> "Address where apps are located")
             .conflicts_with_all(probe_args_ids.clone().collect::<Vec<_>>()),
         arg!(--tab <TAB> "Specify the path of the tab file"),
+        arg!(--"no-replace" "Install alongside an existing app of the same name instead of overwriting it")
+            .action(clap::ArgAction::SetTrue),
     ]
     // Note: the .action(clap::ArgAction::SetTrue) doesn't seem to be necessary, though in clap documentation it is used.
 }

--- a/tockloader-cli/src/main.rs
+++ b/tockloader-cli/src/main.rs
@@ -11,6 +11,7 @@ use clap::ArgMatches;
 use cli::make_cli;
 use known_boards::KnownBoardNames;
 use tockloader_lib::board_settings::BoardSettings;
+use tockloader_lib::command_impl::install::InstallResolution;
 use tockloader_lib::connection::{
     Connection, ProbeRSConnection, ProbeTargetInfo, SerialConnection, SerialTargetInfo,
     TockloaderConnection,
@@ -236,7 +237,7 @@ async fn main() -> Result<()> {
 
             let mut conn = open_connection(sub_matches).await?;
 
-            conn.install_app(tab_file)
+            conn.install_app(tab_file, InstallResolution::Overwrite)
                 .await
                 .context("Failed to install app.")?;
         }

--- a/tockloader-cli/src/main.rs
+++ b/tockloader-cli/src/main.rs
@@ -235,9 +235,16 @@ async fn main() -> Result<()> {
             let tab_file = Tab::open(sub_matches.get_one::<String>("tab").unwrap().to_string())
                 .context("Failed to use provided tab file.")?;
 
+            let no_replace = sub_matches.get_flag("no-replace");
+            let resolution = if no_replace {
+                InstallResolution::InstallAsNew
+            } else {
+                InstallResolution::Overwrite
+            };
+
             let mut conn = open_connection(sub_matches).await?;
 
-            conn.install_app(tab_file, InstallResolution::Overwrite)
+            conn.install_app(tab_file, resolution)
                 .await
                 .context("Failed to install app.")?;
         }

--- a/tockloader-lib/src/command_impl/install.rs
+++ b/tockloader-lib/src/command_impl/install.rs
@@ -1,19 +1,25 @@
 use async_trait::async_trait;
 
 use crate::attributes::app_attributes::AppAttributes;
-use crate::command_impl::reshuffle_apps::{create_pkt, reshuffle_apps, find_conflicting_app, TockApp};
+use crate::command_impl::reshuffle_apps::{
+    create_pkt, find_conflicting_app, reshuffle_apps, TockApp,
+};
 use crate::connection::{Connection, TockloaderConnection};
 use crate::errors::{InternalError, TockloaderError};
 use crate::tabs::tab::Tab;
 use crate::{CommandInstall, CommandList, IO};
 
 pub enum InstallResolution {
-    Overwrite, 
+    Overwrite,
     InstallAsNew,
 }
 #[async_trait]
 impl CommandInstall for TockloaderConnection {
-    async fn install_app(&mut self, tab: Tab, resolution: InstallResolution) -> Result<(), TockloaderError> {
+    async fn install_app(
+        &mut self,
+        tab: Tab,
+        resolution: InstallResolution,
+    ) -> Result<(), TockloaderError> {
         let settings = self.get_settings();
         let app_attributes_list: Vec<AppAttributes> = self.list().await?;
         //create the list of names of the apps on the board
@@ -25,7 +31,9 @@ impl CommandInstall for TockloaderConnection {
         let mut tock_app_list: Vec<TockApp> = app_attributes_list
             .iter()
             .enumerate()
-            .filter(|(i, _)| !(matches!(resolution, InstallResolution::Overwrite) && Some(*i) == conflict_idx))
+            .filter(|(i, _)| {
+                !(matches!(resolution, InstallResolution::Overwrite) && Some(*i) == conflict_idx)
+            })
             .map(|(_, a)| TockApp::from_app_attributes(a))
             .collect();
         log::info!("tock apps len {:?}", tock_app_list.len());
@@ -63,7 +71,8 @@ impl CommandInstall for TockloaderConnection {
 
     async fn find_conflicting_app(&mut self, tab: &Tab) -> Result<Option<String>, TockloaderError> {
         let app_attributes_list = self.list().await?;
-        Ok(app_attributes_list.iter()
+        Ok(app_attributes_list
+            .iter()
             .find(|a| a.tbf_header.get_package_name() == Some(tab.name()))
             .map(|_| tab.name().to_string()))
     }

--- a/tockloader-lib/src/command_impl/install.rs
+++ b/tockloader-lib/src/command_impl/install.rs
@@ -16,6 +16,7 @@ impl CommandInstall for TockloaderConnection {
     async fn install_app(&mut self, tab: Tab, resolution: InstallResolution) -> Result<(), TockloaderError> {
         let settings = self.get_settings();
         let app_attributes_list: Vec<AppAttributes> = self.list().await?;
+        //create the list of names of the apps on the board
         let names: Vec<Option<&str>> = app_attributes_list
             .iter()
             .map(|a| a.tbf_header.get_package_name())

--- a/tockloader-lib/src/command_impl/install.rs
+++ b/tockloader-lib/src/command_impl/install.rs
@@ -1,21 +1,32 @@
 use async_trait::async_trait;
 
 use crate::attributes::app_attributes::AppAttributes;
-use crate::command_impl::reshuffle_apps::{create_pkt, reshuffle_apps, TockApp};
+use crate::command_impl::reshuffle_apps::{create_pkt, reshuffle_apps, find_conflicting_app, TockApp};
 use crate::connection::{Connection, TockloaderConnection};
 use crate::errors::{InternalError, TockloaderError};
 use crate::tabs::tab::Tab;
 use crate::{CommandInstall, CommandList, IO};
 
+pub enum InstallResolution {
+    Overwrite, 
+    InstallAsNew,
+}
 #[async_trait]
 impl CommandInstall for TockloaderConnection {
-    async fn install_app(&mut self, tab: Tab) -> Result<(), TockloaderError> {
+    async fn install_app(&mut self, tab: Tab, resolution: InstallResolution) -> Result<(), TockloaderError> {
         let settings = self.get_settings();
         let app_attributes_list: Vec<AppAttributes> = self.list().await?;
-        let mut tock_app_list = app_attributes_list
+        let names: Vec<Option<&str>> = app_attributes_list
             .iter()
-            .map(TockApp::from_app_attributes)
-            .collect::<Vec<TockApp>>();
+            .map(|a| a.tbf_header.get_package_name())
+            .collect();
+        let conflict_idx = find_conflicting_app(&names, tab.name());
+        let mut tock_app_list: Vec<TockApp> = app_attributes_list
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !(matches!(resolution, InstallResolution::Overwrite) && Some(*i) == conflict_idx))
+            .map(|(_, a)| TockApp::from_app_attributes(a))
+            .collect();
         log::info!("tock apps len {:?}", tock_app_list.len());
 
         // obtain the binaries in a vector
@@ -47,5 +58,12 @@ impl CommandInstall for TockloaderConnection {
         // write the pkt
         let _ = self.write(settings.app_start_address, &pkt).await;
         Ok(())
+    }
+
+    async fn find_conflicting_app(&mut self, tab: &Tab) -> Result<Option<String>, TockloaderError> {
+        let app_attributes_list = self.list().await?;
+        Ok(app_attributes_list.iter()
+            .find(|a| a.tbf_header.get_package_name() == Some(tab.name()))
+            .map(|_| tab.name().to_string()))
     }
 }

--- a/tockloader-lib/src/command_impl/reshuffle_apps.rs
+++ b/tockloader-lib/src/command_impl/reshuffle_apps.rs
@@ -763,10 +763,45 @@ mod tests {
         ]);
         assert_eq!(reshuffled_apps, correct_config);
     }
+
     #[test]
     fn detects_conflict_by_name() {
       let names = vec![Some("blink"), Some("sensor_app")];
       assert_eq!(find_conflicting_app(&names, "sensor_app"), Some(1));
       assert_eq!(find_conflicting_app(&names, "new_app"), None);
+    }
+    
+    #[test]
+    fn overwrite_drops_conflicting_app_before_reshuffle() {
+      // Two installed apps already on the board.
+      let old_app = TockApp::Flexible(FlexibleApp {
+        installed: true,
+        idx: Some(0),
+        size: 0x2000,
+      });
+      let other_app = TockApp::Flexible(FlexibleApp {
+        installed: true,
+        idx: Some(1),
+        size: 0x1000,
+      });
+
+      let apps = vec![old_app, other_app];
+
+      let conflict_idx = Some(0);
+      let resolution_is_overwrite = true;
+
+      let filtered: Vec<TockApp> = apps
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !(resolution_is_overwrite && Some(*i) == conflict_idx))
+        .map(|(_, a)| a)
+        .collect();
+
+      // The conflicting app (index 0) should be gone; the other one stays.
+      assert_eq!(filtered.len(), 1);
+      match &filtered[0] {
+        TockApp::Flexible(f) => assert_eq!(f.idx, Some(1)),
+        _ => panic!("expected the remaining app to be the Flexible variant with idx 1"),
+      }
     }
 }

--- a/tockloader-lib/src/command_impl/reshuffle_apps.rs
+++ b/tockloader-lib/src/command_impl/reshuffle_apps.rs
@@ -473,7 +473,7 @@ fn align_down(address: u64) -> u64 {
 }
 
 /// This functions detects name conflict with an already installed app
-pub fn find_conflicting_app(installed_names: &[Option<&str>], new_name: &str) -> Option<usize>{
+pub fn find_conflicting_app(installed_names: &[Option<&str>], new_name: &str) -> Option<usize> {
     installed_names.iter().position(|n| *n == Some(new_name))
 }
 
@@ -766,42 +766,42 @@ mod tests {
 
     #[test]
     fn detects_conflict_by_name() {
-      let names = vec![Some("blink"), Some("sensor_app")];
-      assert_eq!(find_conflicting_app(&names, "sensor_app"), Some(1));
-      assert_eq!(find_conflicting_app(&names, "new_app"), None);
+        let names = vec![Some("blink"), Some("sensor_app")];
+        assert_eq!(find_conflicting_app(&names, "sensor_app"), Some(1));
+        assert_eq!(find_conflicting_app(&names, "new_app"), None);
     }
-    
+
     #[test]
     fn overwrite_drops_conflicting_app_before_reshuffle() {
-      // Two installed apps already on the board.
-      let old_app = TockApp::Flexible(FlexibleApp {
-        installed: true,
-        idx: Some(0),
-        size: 0x2000,
-      });
-      let other_app = TockApp::Flexible(FlexibleApp {
-        installed: true,
-        idx: Some(1),
-        size: 0x1000,
-      });
+        // Two installed apps already on the board.
+        let old_app = TockApp::Flexible(FlexibleApp {
+            installed: true,
+            idx: Some(0),
+            size: 0x2000,
+        });
+        let other_app = TockApp::Flexible(FlexibleApp {
+            installed: true,
+            idx: Some(1),
+            size: 0x1000,
+        });
 
-      let apps = vec![old_app, other_app];
+        let apps = vec![old_app, other_app];
 
-      let conflict_idx = Some(0);
-      let resolution_is_overwrite = true;
+        let conflict_idx = Some(0);
+        let resolution_is_overwrite = true;
 
-      let filtered: Vec<TockApp> = apps
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| !(resolution_is_overwrite && Some(*i) == conflict_idx))
-        .map(|(_, a)| a)
-        .collect();
+        let filtered: Vec<TockApp> = apps
+            .into_iter()
+            .enumerate()
+            .filter(|(i, _)| !(resolution_is_overwrite && Some(*i) == conflict_idx))
+            .map(|(_, a)| a)
+            .collect();
 
-      // The conflicting app (index 0) should be gone; the other one stays.
-      assert_eq!(filtered.len(), 1);
-      match &filtered[0] {
-        TockApp::Flexible(f) => assert_eq!(f.idx, Some(1)),
-        _ => panic!("expected the remaining app to be the Flexible variant with idx 1"),
-      }
+        // The conflicting app (index 0) should be gone; the other one stays.
+        assert_eq!(filtered.len(), 1);
+        match &filtered[0] {
+            TockApp::Flexible(f) => assert_eq!(f.idx, Some(1)),
+            _ => panic!("expected the remaining app to be the Flexible variant with idx 1"),
+        }
     }
 }

--- a/tockloader-lib/src/command_impl/reshuffle_apps.rs
+++ b/tockloader-lib/src/command_impl/reshuffle_apps.rs
@@ -472,6 +472,11 @@ fn align_down(address: u64) -> u64 {
     address - address % ALIGNMENT
 }
 
+/// This functions detects name conflict with an already installed app
+pub fn find_conflicting_app(installed_names: &[Option<&str>], new_name: &str) -> Option<usize>{
+    installed_names.iter().position(|n| *n == Some(new_name))
+}
+
 /// This function creates the full binary that will be written
 pub fn create_pkt(
     configuration: Vec<Index>,
@@ -757,5 +762,11 @@ mod tests {
             },
         ]);
         assert_eq!(reshuffled_apps, correct_config);
+    }
+    #[test]
+    fn detects_conflict_by_name() {
+      let names = vec![Some("blink"), Some("sensor_app")];
+      assert_eq!(find_conflicting_app(&names, "sensor_app"), Some(1));
+      assert_eq!(find_conflicting_app(&names, "new_app"), None);
     }
 }

--- a/tockloader-lib/src/command_impl/reshuffle_apps.rs
+++ b/tockloader-lib/src/command_impl/reshuffle_apps.rs
@@ -394,7 +394,7 @@ pub fn reshuffle_apps(
                             installed: false,
                             idx: None,
                             ram_address: None,
-                            address: settings.app_start_address + insert_size,
+                            address: gap_start,
                             size: needed_padding,
                         });
                         reordered_apps.push(c_app.as_index(None, gap_start + needed_padding));

--- a/tockloader-lib/src/lib.rs
+++ b/tockloader-lib/src/lib.rs
@@ -20,6 +20,7 @@ use crate::attributes::general_attributes::GeneralAttributes;
 use crate::attributes::system_attributes::SystemAttributes;
 use crate::errors::*;
 use crate::tabs::tab::Tab;
+use crate::command_impl::install::InstallResolution;
 
 pub fn list_debug_probes() -> Vec<DebugProbeInfo> {
     probe_rs::probe::list::Lister::new().list_all()
@@ -47,7 +48,8 @@ pub trait CommandInfo {
 
 #[async_trait]
 pub trait CommandInstall {
-    async fn install_app(&mut self, tab_file: Tab) -> Result<(), TockloaderError>;
+    async fn install_app(&mut self, tab_file: Tab, resolution: InstallResolution) -> Result<(), TockloaderError>;
+    async fn find_conflicting_app(&mut self, tab: &Tab) -> Result<Option<String>, TockloaderError>;
 }
 
 #[async_trait]

--- a/tockloader-lib/src/lib.rs
+++ b/tockloader-lib/src/lib.rs
@@ -18,9 +18,9 @@ use tokio_serial::SerialPortInfo;
 use crate::attributes::app_attributes::AppAttributes;
 use crate::attributes::general_attributes::GeneralAttributes;
 use crate::attributes::system_attributes::SystemAttributes;
+use crate::command_impl::install::InstallResolution;
 use crate::errors::*;
 use crate::tabs::tab::Tab;
-use crate::command_impl::install::InstallResolution;
 
 pub fn list_debug_probes() -> Vec<DebugProbeInfo> {
     probe_rs::probe::list::Lister::new().list_all()
@@ -48,7 +48,11 @@ pub trait CommandInfo {
 
 #[async_trait]
 pub trait CommandInstall {
-    async fn install_app(&mut self, tab_file: Tab, resolution: InstallResolution) -> Result<(), TockloaderError>;
+    async fn install_app(
+        &mut self,
+        tab_file: Tab,
+        resolution: InstallResolution,
+    ) -> Result<(), TockloaderError>;
     async fn find_conflicting_app(&mut self, tab: &Tab) -> Result<Option<String>, TockloaderError>;
 }
 

--- a/tockloader-lib/src/tabs/tab.rs
+++ b/tockloader-lib/src/tabs/tab.rs
@@ -140,7 +140,7 @@ impl Tab {
 
         Err(TabError::MissingBinary(arch.to_owned()).into())
     }
-    pub fn name(&self) -> &str{
+    pub fn name(&self) -> &str {
         &self.metadata.name
     }
 }

--- a/tockloader-lib/src/tabs/tab.rs
+++ b/tockloader-lib/src/tabs/tab.rs
@@ -140,4 +140,7 @@ impl Tab {
 
         Err(TabError::MissingBinary(arch.to_owned()).into())
     }
+    pub fn name(&self) -> &str{
+        &self.metadata.name
+    }
 }


### PR DESCRIPTION
### Pull Request Overview

<!--
This pull request changes the install command. If user tries to install the same application twice without the --no-replace flag, tockloader ignores the request. If the user mentions --no-replace flag, it is installed again
-->

### Checks

#### Using Rust tooling
- [✓] Ran `cargo fmt`
- [✓] Ran `cargo clippy`
- [✓] Ran `cargo test`
- [✓] Ran `cargo build`

#### Features tested:
- [✓] ***install command*** on ***nucleo-u545re-q***


### GitHub Issue

<!--
This pull request closes <Issue #130 >
-->